### PR TITLE
Add removal of duplicated columns after dplyr::join + trailing space

### DIFF
--- a/R/common_functions.R
+++ b/R/common_functions.R
@@ -1,12 +1,12 @@
 #' Some functions used in one or several functions of PPBstats
-#' 
+#'
 #' @name common_functions
-#' 
+#'
 #' @description
 #' This file group functions used in several functions of PPBstats
-#' 
+#'
 #' @author Pierre Riviere
-#' 
+#'
 
 # check_data_vec_variables ----------
 #' check if variable are part of the data
@@ -15,7 +15,7 @@
 #' @export
 check_data_vec_variables = function(data, vec_variables){
   for(variable in vec_variables) { if(!is.element(variable, colnames(data))) { stop(variable," is not in data") } }
-  for(variable in vec_variables) { 
+  for(variable in vec_variables) {
     if(!is.numeric(data[,variable])) { stop(variable," is not numeric") } }
 }
 
@@ -27,7 +27,7 @@ check_data_vec_variables = function(data, vec_variables){
 #' @export
 #' @import plyr
 split_data_for_ggplot = function(data, factor, nb_param){
-  split_factor = NULL # to avoid no visible binding for global variable 
+  split_factor = NULL # to avoid no visible binding for global variable
   ns = unique(data[,factor])
   s = rep(c(1:length(ns)), each = nb_param)[1:length(ns)]
   names(s) = ns
@@ -43,38 +43,38 @@ split_data_for_ggplot = function(data, factor, nb_param){
 #' @import ggplot2
 get_biplot = function(res.pca){
   x = y = label = NULL # to avoid no visible binding for global variable
-  
+
   var = as.data.frame(res.pca$var$coord)
   var = cbind.data.frame(rownames(var), var, color = "darkgreen"); colnames(var)[1:3] = c("label", "x", "y")
-  
+
   ind = as.data.frame(res.pca$ind$coord)
   ind = cbind.data.frame(rownames(ind), ind, color = "black"); colnames(ind)[1:3] = c("label", "x", "y")
-  
+
   r <- min((max(ind[, "x"]) - min(ind[, "x"])/(max(var[, "x"]) - min(var[, "x"]))), (max(ind[, "y"]) - min(ind[, "y"])/(max(var[, "y"]) - min(var[, "y"]))))
   var[, c("x", "y")] <- var[, c("x", "y")] * r * 0.7 # taken from factoextra::fviz_pca_biplot
-  
+
   vi = rbind.data.frame(var, ind)
   vi$size = 4
   vi$size[which(vi$color == "darkgreen")] = 6
-  
+
   dimvar = round(as.data.frame(res.pca$eig)$`percentage of variance`[1:2], 1)
-  
+
   p = ggplot(data = vi, aes(x = x, y = y, label = label)) + geom_text(color = as.character(vi$color), size = vi$size) + geom_point(color = as.character(vi$color))
   p = p + xlab(paste("Dim 1 (", dimvar[1], "%)", sep = "")) + ylab(paste("Dim 2 (", dimvar[2], "%)", sep = ""))
   p = p + ggtitle("Biplot germplasm and locations")
   p = p + geom_vline(xintercept = 0, linetype = "longdash",color="grey") + geom_hline(yintercept = 0, linetype = "longdash",color="grey")
-  
+
   return(p)
 }
 
 # get_perpendicular_segment ----------
 #' get coordinate to draw perpendicular segment
-#' @param x1 x coordinate of point 1 
-#' @param y1 y coordinate of point 1 
-#' @param x2 x coordinate of point 2 
-#' @param y2 y coordinate of point 2 
-#' @param x3 x coordinate of point 3 
-#' @param y3 y coordinate of point 3 
+#' @param x1 x coordinate of point 1
+#' @param y1 y coordinate of point 1
+#' @param x2 x coordinate of point 2
+#' @param y2 y coordinate of point 2
+#' @param x3 x coordinate of point 3
+#' @param y3 y coordinate of point 3
 #' @param longer TRUE or FALSE
 #' @details following formulas thanks to jdbertron cf http://stackoverflow.com/questions/10301001/perpendicular-on-a-line-segment-from-a-given-point
 #' @export
@@ -85,13 +85,13 @@ get_perpendicular_segment = function(x1, y1, x2, y2, x3, y3, longer = FALSE){
   u = ((x3 - x1) * px + (y3 - y1) * py) / dAB
   x4 = x1 + u * px
   y4 = y1 + u * py
-  
+
   # to make the segment longer
   if(longer & x4 != 0){
     y4 = y4/x4 * x4*1000000
     x4 = x4*1000000
   }
-  
+
   return(c(x1 = x3, y1 = y3, x2 = x4, y2 = y4))
 }
 
@@ -101,15 +101,15 @@ get_perpendicular_segment = function(x1, y1, x2, y2, x3, y3, longer = FALSE){
 #' @param analysis type of analysis : "experimental_design", "convergence" or "posteriors"
 #' @export
 check_analysis_argument = function(analysis){
-  if(!is.null(analysis)) { 
-    if( !is.element(analysis, c("experimental_design", "convergence", "posteriors")) ){ stop("analysis must be \"experimental_design\", \"convergence\" or \"posteriors\".") }  
-    if( !is.element(analysis, c("convergence")) ){ warning("\"convergence\" is not chosen! You may make mistakes in the interpretation of the results !!!") }  
+  if(!is.null(analysis)) {
+    if( !is.element(analysis, c("experimental_design", "convergence", "posteriors")) ){ stop("analysis must be \"experimental_design\", \"convergence\" or \"posteriors\".") }
+    if( !is.element(analysis, c("convergence")) ){ warning("\"convergence\" is not chosen! You may make mistakes in the interpretation of the results !!!") }
   } else { analysis = "all" }
   return(analysis)
 }
 
 # check_convergence ----------
-#' check convergence of bayesian model 
+#' check convergence of bayesian model
 #' @param out.model output from bayesian model
 #' @param model_name name of the model
 #' @export
@@ -118,20 +118,20 @@ check_convergence = function(out.model, model_name = "model1"){
   MCMC = out.model$MCMC
   MCMC = rbind.data.frame(MCMC[[1]], MCMC[[2]])
   attributes(MCMC)$model = model_name
-  
+
   s = summary(out.model$MCMC)
   sq_MCMC = as.data.frame(s$quantiles)
   sq_MCMC$parameter = as.factor(rownames(sq_MCMC))
   colnames(sq_MCMC) = c("q1", "q2", "q3", "q4", "q5", "parameter")
-  
+
   message("The Gelman-Rubin test is running for each parameter ...")
   test = coda::gelman.diag(out.model$MCMC, multivariate = FALSE)$psrf[,1]
   conv_ok = names(which(test < 1.05))
   conv_not_ok = names(which(test > 1.05))
-  
+
   if( length(conv_not_ok) > 0 ) {
     message("The two MCMC of the following parameters do not converge thanks to the Gelman-Rubin test : ", paste(conv_not_ok, collapse = ", ") ,". Therefore, they are not present in MCMC output.")
-    } else { 
+    } else {
     message("The two MCMC for each parameter converge thanks to the Gelman-Rubin test.")
     }
   OUT = list("MCMC" = MCMC, "sq_MCMC" = sq_MCMC, "conv_not_ok" = conv_not_ok)
@@ -147,9 +147,9 @@ check_convergence = function(out.model, model_name = "model1"){
 #' @import ggplot2
 get.caterpillar.plot = function(x, xmin, xmax){ # cf ggmcmc:ggs_caterpillar
   parameter = q1 = q2 = q3 = q4 = q5 = NULL # to avoid no visible binding for global variable
-  
-  p = ggplot(x, aes(x = q3, y = reorder(parameter, q3))) 
-  p = p + geom_point(size = 3) # median 
+
+  p = ggplot(x, aes(x = q3, y = reorder(parameter, q3)))
+  p = p + geom_point(size = 3) # median
   p = p + geom_segment(aes(x = q2, xend = q4, yend = reorder(parameter, q3)), size = 1.5) # 25%-75%
   p = p + geom_segment(aes(x = q1, xend = q5, yend = reorder(parameter, q3)), size = 0.5) # 2.5%-25% and 75%-97.5%
   p = p + ylab("parameter") + xlab("value") + ggtitle(x[1, "environment"])
@@ -164,8 +164,8 @@ get.caterpillar.plot = function(x, xmin, xmax){ # cf ggmcmc:ggs_caterpillar
 #' @import ggplot2
 get_mcmc_traceplot_density = function(MCMC){
   Iteration = value = Chain  = NULL # to avoid no visible binding for global variable
-  
-  if( is.vector(MCMC) ) { 
+
+  if( is.vector(MCMC) ) {
     mcmc = as.data.frame(matrix(MCMC, ncol = 1))
     colnames(mcmc) = names(MCMC)[1]
     MCMC = mcmc
@@ -173,9 +173,9 @@ get_mcmc_traceplot_density = function(MCMC){
   conv_not_ok = colnames(MCMC)
   vec.plot = NULL
   for (para in conv_not_ok) {
-    D = cbind.data.frame(Iteration = rep(c(1:(nrow(MCMC)/2)), 2), 
-                         Chain = factor(rep(c(1,2), each = (nrow(MCMC)/2))), 
-                         Parameter = para, 
+    D = cbind.data.frame(Iteration = rep(c(1:(nrow(MCMC)/2)), 2),
+                         Chain = factor(rep(c(1,2), each = (nrow(MCMC)/2))),
+                         Parameter = para,
                          value = as.vector(MCMC[,para])
     )
     traceplot = ggplot(D, aes(x = Iteration, y = value, color = Chain)) + geom_line() + ggtitle(para) # cf ggmcmc:ggs_traceplot
@@ -190,7 +190,7 @@ get_mcmc_traceplot_density = function(MCMC){
 
 # get_mean_comparisons_and_Mpvalue ----------
 #' get mean comparisons and square matrix with pvalue from MCMC for bayesian models
-#' @param MCMC MCMC 
+#' @param MCMC MCMC
 #' @param parameter parameter
 #' @param type type
 #' @param threshold threshold
@@ -202,48 +202,48 @@ get_mcmc_traceplot_density = function(MCMC){
 #' @export
 get_mean_comparisons_and_Mpvalue = function(MCMC, parameter, type, threshold, alpha, p.adj, precision, get.at.least.X.groups){
   element = NULL # to avoid no visible binding for global variable
-  
+
   if( !is.element(type, c(1,2)) ){ stop("type must be 1 or 2") }
 
   Mpvalue = comp.parameters(MCMC = MCMC, parameter = parameter, type = type, threshold = threshold)
-  
+
   if(type == 1 & is.null(Mpvalue)) { message("mean comparisons not done for ", sub("\\\\\\[", "", element), " because there are less than two parameters to compare.") }
-  
-  
+
+
   if(type == 1 & !is.null(Mpvalue)) {
     Comparison = get.significant.groups(Mpvalue = Mpvalue, MCMC = MCMC, alpha = alpha, p.adj = p.adj)
-    
+
     # number of groups
     a = unlist(strsplit(paste(Comparison[, "groups"], collapse = ""), ""))
     nb_group = length(unique(a))
-    
+
     # get at least X groups
     if(nb_group == 1 & !is.null(get.at.least.X.groups)) {
       env = sub("\\]", "", unique(sapply(colnames(MCMC), function(x){unlist(strsplit(x, ","))[2]})))
       message(paste("Get at least X groups for ", sub("\\\\\\[", "", env),". It may take some time ...", sep = "")) # The sub is useful for model2
-      ALPHA = get.at.least.X.groups(Mpvalue, MCMC, p.adj = p.adj, precision = precision)  
-      alp = ALPHA[paste(get.at.least.X.groups, "_groups", sep = "")]  
+      ALPHA = get.at.least.X.groups(Mpvalue, MCMC, p.adj = p.adj, precision = precision)
+      alp = ALPHA[paste(get.at.least.X.groups, "_groups", sep = "")]
       if(is.numeric(alp)){ alp = round(alp, 3) }
       message(paste("Get at least X groups for", sub("\\\\\\[", "", env),"is done."))
     } else { alp = alpha }
-    
+
     TAB = cbind.data.frame("parameter" = Comparison$parameter,
-                           "median" = Comparison$median, 
-                           "groups" = Comparison$groups, 
-                           "nb_group" = rep(nb_group, nrow(Comparison)), 
+                           "median" = Comparison$median,
+                           "groups" = Comparison$groups,
+                           "nb_group" = rep(nb_group, nrow(Comparison)),
                            "alpha" = rep(alp, nrow(Comparison)),
                            "alpha.correction" = rep(p.adj, nrow(Comparison))
     )
-    
+
   }
-  
-  if(type == 2) { 
-    TAB = cbind.data.frame("proba" = Mpvalue) 
+
+  if(type == 2) {
+    TAB = cbind.data.frame("proba" = Mpvalue)
     o = order(TAB$proba)
     tab = as.data.frame(matrix(TAB[o,], ncol = 1)); rownames(tab) = rownames(TAB)[o]
     TAB = tab
   }
-  
+
   out = list(TAB, Mpvalue)
   names(out) = c("mean.comparisons", "Mpvalue")
   return(out)
@@ -254,15 +254,15 @@ get_mean_comparisons_and_Mpvalue = function(MCMC, parameter, type, threshold, al
 #' @param x vector
 #' @param each nb of element iln each split
 #' @export
-add_split_col = function(x, each){ rep(c(1:nrow(x)), each = each)[1:nrow(x)] } 
+add_split_col = function(x, each){ rep(c(1:nrow(x)), each = each)[1:nrow(x)] }
 
 # is.inside.sector ----------
 #' to know if a point is inside an area
 #' @param x x coordinate of point to know if it is inside the area or not
 #' @param y y coordinate of point to know if it is inside the area or not
-#' @param x1 x coordinate of point 1 of the area 
+#' @param x1 x coordinate of point 1 of the area
 #' @param y1 y coordinate of point 1 of the area
-#' @param x2 x coordinate of point 2 of the area 
+#' @param x2 x coordinate of point 2 of the area
 #' @param y2 y coordinate of point 2 of the area
 #' @param x3 x coordinate of point 3 of the area
 #' @param y3 y coordinate of point 3 of the area
@@ -271,7 +271,7 @@ add_split_col = function(x, each){ rep(c(1:nrow(x)), each = each)[1:nrow(x)] }
 is.inside.sector = function(x, y, x1, y1, x2, y2, x3, y3){
   # resolve it with barycentric coordinates
   # thanks to andreasdr, cf http://stackoverflow.com/questions/2049582/how-to-determine-if-a-point-is-in-a-2d-triangle
-  
+
   p0y = y1
   p0x = x1
   p1y = y2
@@ -280,11 +280,11 @@ is.inside.sector = function(x, y, x1, y1, x2, y2, x3, y3){
   p2x = x3
   py = y
   px = x
-  
+
   Area = 0.5 *(-p1y*p2x + p0y*(-p1x + p2x) + p0x*(p1y - p2y) + p1x*p2y)
   s = 1/(2*Area)*(p0y*p2x - p0x*p2y + (p2y - p0y)*px + (p0x - p2x)*py)
   t = 1/(2*Area)*(p0x*p1y - p0y*p1x + (p0y - p1y)*px + (p1x - p0x)*py)
-  
+
   test = s > 0 & t > 0 & (1-s-t) > 0
   return(test)
 }
@@ -304,27 +304,27 @@ is.inside.sector = function(x, y, x1, y1, x2, y2, x3, y3){
 #' @import dplyr
 #' @import plyr
 reshape_data_split_x_axis_in_col = function(
-  d, 
-  vec_variables, 
+  d,
+  vec_variables,
   labels_on,
-  x_axis, 
-  nb_parameters_per_plot_x_axis, 
-  in_col, 
+  x_axis,
+  nb_parameters_per_plot_x_axis,
+  in_col,
   nb_parameters_per_plot_in_col
 ){
   split_x_axis = split_in_col  = NULL  # to avoid no visible binding for global variable
-  
+
   if(!is.null(x_axis)){ d$x_axis = as.factor(as.character(d[,x_axis])) } else { d$x_axis = NA }
   if(!is.null(in_col)){ d$in_col = as.factor(as.character(d[,in_col])) } else { d$in_col = NA }
   if(!is.null(labels_on)){ d$labels_text = d[,labels_on] } else { d$labels_text = NA }
   d_head = d[,c("labels_text", "x_axis", "in_col")]
-  
+
   if( length(vec_variables) == 1) {
     d_var = as.data.frame(as.matrix(d[,vec_variables], ncol = 1))
-  } else { 
+  } else {
     d_var = d[,vec_variables]
     }
-  
+
   # get rid off rows with only NA
   tokeep = apply(d_var, 1, function(x){length(which(is.na(x))) != length(x)})
   t = length(which(!tokeep))
@@ -336,10 +336,10 @@ reshape_data_split_x_axis_in_col = function(
     d_var = d_var[tokeep,]
   }
   colnames(d_var) = vec_variables
-  
+
   d_head = d_head[tokeep,]
   d = droplevels(cbind.data.frame(d_head, d_var))
-  
+
   # split for x_axis
   if(!is.null(x_axis)){
     ns = unique(d$x_axis)
@@ -347,7 +347,7 @@ reshape_data_split_x_axis_in_col = function(
     names(s) = ns
     d$split_x_axis = s[d$x_axis]
   } else { d$split_x_axis = NA }
-  
+
   # split for in_col
   if(!is.null(in_col)){
     ns = unique(d$in_col)
@@ -355,17 +355,17 @@ reshape_data_split_x_axis_in_col = function(
     names(s) = ns
     d$split_in_col = s[d$in_col]
   } else { d$split_in_col = NA }
-  
+
   # Overall split
   d$split = paste(
-    paste(x_axis, d$split_x_axis, sep = "-"), 
-    paste(in_col, d$split_in_col, sep = "-"), 
+    paste(x_axis, d$split_x_axis, sep = "-"),
+    paste(in_col, d$split_in_col, sep = "-"),
     sep = "|")
   d = dplyr::select(d, - split_x_axis, - split_in_col)
   d = plyr:::splitter_d(d, .(split))
-  
+
   return(d)
-}		
+}
 
 # ggradar ----------
 #' ggradar
@@ -408,8 +408,8 @@ reshape_data_split_x_axis_in_col = function(
 #' @import ggplot2
 ggradar <- function(plot.data,
                     font.radar="Circular Air Light",
-                    values.radar = c("0%", "50%", "100%"),                       
-                    axis.labels=colnames(plot.data)[-1],                             
+                    values.radar = c("0%", "50%", "100%"),
+                    axis.labels=colnames(plot.data)[-1],
                     grid.min=0,  #10,
                     grid.mid=0.5,  #50,
                     grid.max=1,  #100,
@@ -441,29 +441,29 @@ ggradar <- function(plot.data,
                     plot.title="",
                     legend.text.size=grid.label.size ) {
   x = y = text = axis.no  = NULL  # to avoid no visible binding for global variable
-  
+
   plot.data <- as.data.frame(plot.data)
-  
+
   plot.data[,1] <- as.factor(as.character(plot.data[,1]))
   names(plot.data)[1] <- "group"
-  
-  var.names <- colnames(plot.data)[-1]  #'Short version of variable names 
+
+  var.names <- colnames(plot.data)[-1]  #'Short version of variable names
   #axis.labels [if supplied] is designed to hold 'long version' of variable names
   #with line-breaks indicated using \n
-  
+
   #calculate total plot extent as radius of outer circle x a user-specifiable scaling factor
   plot.extent.x=(grid.max+abs(centre.y))*plot.extent.x.sf
   plot.extent.y=(grid.max+abs(centre.y))*plot.extent.y.sf
-  
+
   #Check supplied data makes sense
-  if (length(axis.labels) != ncol(plot.data)-1) 
-    return("Error: 'axis.labels' contains the wrong number of axis labels") 
+  if (length(axis.labels) != ncol(plot.data)-1)
+    return("Error: 'axis.labels' contains the wrong number of axis labels")
   if(min(plot.data[,-1])<centre.y)
     return("Error: plot.data' contains value(s) < centre.y")
   if(max(plot.data[,-1])>grid.max)
     return("Error: 'plot.data' contains value(s) > grid.max")
   #Declare required internal functions
-  
+
   CalculateGroupPath <- function(df) {
     #Converts variable values into a set of radial x-y coordinates
     #Code adapted from a solution posted by Tony M to
@@ -471,27 +471,27 @@ ggradar <- function(plot.data,
     #Args:
     #  df: Col 1 -  group ('unique' cluster / group ID of entity)
     #      Col 2-n:  v1.value to vn.value - values (e.g. group/cluser mean or median) of variables v1 to v.n
-    
+
     path <- df[,1]
-    
+
     ##find increment
     angles = seq(from=0, to=2*pi, by=(2*pi)/(ncol(df)-1))
     ##create graph data frame
     graphData= data.frame(seg="", x=0,y=0)
     graphData=graphData[-1,]
-    
+
     for(i in levels(path)){
       pathData = subset(df, df[,1]==i)
       for(j in c(2:ncol(df))){
         #pathData[,j]= pathData[,j]
-        
-        
-        graphData=rbind(graphData, data.frame(group=i, 
+
+
+        graphData=rbind(graphData, data.frame(group=i,
                                               x=pathData[,j]*sin(angles[j-1]),
                                               y=pathData[,j]*cos(angles[j-1])))
       }
       ##complete the path by repeating first pair of coords in the path
-      graphData=rbind(graphData, data.frame(group=i, 
+      graphData=rbind(graphData, data.frame(group=i,
                                             x=pathData[,2]*sin(angles[1]),
                                             y=pathData[,2]*cos(angles[1])))
     }
@@ -534,9 +534,9 @@ ggradar <- function(plot.data,
     yy <- center[2] + r * sin(tt)
     return(data.frame(x = xx, y = yy))
   }
-  
+
   ### Convert supplied data into plottable format
-  # (a) add abs(centre.y) to supplied plot data 
+  # (a) add abs(centre.y) to supplied plot data
   #[creates plot centroid of 0,0 for internal use, regardless of min. value of y
   # in user-supplied data]
   plot.data.offset <- plot.data
@@ -545,7 +545,7 @@ ggradar <- function(plot.data,
   # (b) convert into radial coords
   group <-NULL
   group$path <- CalculateGroupPath(plot.data.offset)
-  
+
   #print(group$path)
   # (c) Calculate coordinates required to plot radial variable axes
   axis <- NULL
@@ -583,10 +583,10 @@ ggradar <- function(plot.data,
   #print(gridline$max$label)
   #print(gridline$mid$label)
   ### Start building up the radar plot
-  
+
   # Declare 'theme_clear', with or without a plot legend as required by user
   #[default = no legend if only 1 group [path] being plotted]
-  theme_clear <- theme_bw(base_size=20) + 
+  theme_clear <- theme_bw(base_size=20) +
     theme(axis.text.y=element_blank(),
           axis.text.x=element_blank(),
           axis.ticks=element_blank(),
@@ -594,26 +594,26 @@ ggradar <- function(plot.data,
           panel.grid.minor=element_blank(),
           panel.border=element_blank(),
           legend.key=element_rect(linetype="blank"))
-  
+
   if (plot.legend==FALSE) theme_clear <- theme_clear + theme(legend.position="none")
-  
+
   #Base-layer = axis labels + plot extent
   # [need to declare plot extent as well, since the axis labels don't always
   # fit within the plot area automatically calculated by ggplot, even if all
   # included in first plot; and in any case the strategy followed here is to first
-  # plot right-justified labels for axis labels to left of Y axis for x< (-x.centre.range)], 
-  # then centred labels for axis labels almost immediately above/below x= 0 
+  # plot right-justified labels for axis labels to left of Y axis for x< (-x.centre.range)],
+  # then centred labels for axis labels almost immediately above/below x= 0
   # [abs(x) < x.centre.range]; then left-justified axis labels to right of Y axis [x>0].
-  # This building up the plot in layers doesn't allow ggplot to correctly 
+  # This building up the plot in layers doesn't allow ggplot to correctly
   # identify plot extent when plotting first (base) layer]
-  
+
   #base layer = axis labels for axes to left of central y-axis [x< -(x.centre.range)]
   base <- ggplot(axis$label) + xlab(NULL) + ylab(NULL) + coord_equal() +
     geom_text(data=subset(axis$label,axis$label$x < (-x.centre.range)),
               aes(x=x,y=y,label=text),size=axis.label.size,hjust=1, family=font.radar) +
-    scale_x_continuous(limits=c(-1.5*plot.extent.x,1.5*plot.extent.x)) + 
+    scale_x_continuous(limits=c(-1.5*plot.extent.x,1.5*plot.extent.x)) +
     scale_y_continuous(limits=c(-plot.extent.y,plot.extent.y))
-  
+
   # + axis labels for any vertical axes [abs(x)<=x.centre.range]
   base <- base + geom_text(data=subset(axis$label,abs(axis$label$x)<=x.centre.range),
                            aes(x=x,y=y,label=text),size=axis.label.size,hjust=0.5, family=font.radar)
@@ -626,20 +626,20 @@ ggradar <- function(plot.data,
   base <- base + geom_polygon(data=gridline$max$path,aes(x,y),
                               fill=background.circle.colour,
                               alpha=background.circle.transparency)
-  
+
   # + radial axes
   base <- base + geom_path(data=axis$path,aes(x=x,y=y,group=axis.no),
                            colour=axis.line.colour)
-  
-  
+
+
   # ... + group (cluster) 'paths'
   base <- base + geom_path(data=group$path,aes(x=x,y=y,group=group,colour=group),
                            size=group.line.width)
-  
+
   # ... + group points (cluster data)
   base <- base + geom_point(data=group$path,aes(x=x,y=y,group=group,colour=group),size=group.point.size)
-  
-  
+
+
   #... + amend Legend title
   if (plot.legend==TRUE) base  <- base + labs(colour=legend.title,size=legend.text.size)
   # ... + circular grid-lines at 'min', 'mid' and 'max' y-axis values
@@ -651,7 +651,7 @@ ggradar <- function(plot.data,
                             lty=gridline.max.linetype,colour=gridline.max.colour,size=grid.line.width)
   # ... + grid-line labels (max; ave; min) [only add min. gridline label if required]
   if (label.gridline.min==TRUE) {
-    
+
     base <- base + geom_text(aes(x=x,y=y,label=values.radar[1]),data=gridline$min$label,size=grid.label.size*0.8, hjust=1, family=font.radar) }
   base <- base + geom_text(aes(x=x,y=y,label=values.radar[2]),data=gridline$mid$label,size=grid.label.size*0.8, hjust=1, family=font.radar)
   base <- base + geom_text(aes(x=x,y=y,label=values.radar[3]),data=gridline$max$label,size=grid.label.size*0.8, hjust=1, family=font.radar)
@@ -659,28 +659,28 @@ ggradar <- function(plot.data,
   if (label.centre.y==TRUE) {
     centre.y.label <- data.frame(x=0, y=0, text=as.character(centre.y))
     base <- base + geom_text(aes(x=x,y=y,label=text),data=centre.y.label,size=grid.label.size, hjust=0.5, family=font.radar) }
-  
+
   if (!is.null(group.colours)){
     colour_values=rep(group.colours,100)
   } else {
-    colour_values=rep(c("#FF5A5F", "#FFB400", "#007A87",  "#8CE071", "#7B0051", 
+    colour_values=rep(c("#FF5A5F", "#FFB400", "#007A87",  "#8CE071", "#7B0051",
                         "#00D1C1", "#FFAA91", "#B4A76C", "#9CA299", "#565A5C", "#00A04B", "#E54C20"), 100)
   }
-  
+
   base <- base + theme(legend.key.width=unit(3,"line")) + theme(text = element_text(size = 20,
                                                                                     family = font.radar)) +
     theme(legend.text = element_text(size = legend.text.size), legend.position="left") +
     theme(legend.key.height=unit(2,"line")) +
     scale_colour_manual(values=colour_values) +
-    theme(text=element_text(family=font.radar)) + 
+    theme(text=element_text(family=font.radar)) +
     theme(legend.title=element_blank())
-  
+
   if (plot.title != "") {
     base <- base + ggtitle(plot.title)
   }
-  
+
   return(base)
-  
+
 }
 
 
@@ -691,25 +691,25 @@ ggradar <- function(plot.data,
 #' @import agricolae
 check_freq_anova = function(model){
   r = y = percentage_Sum_sq  = NULL  # to avoid no visible binding for global variable
-  
+
   anova_model = stats::anova(model)
   # 1. Check residuals (qqplot, Skewness & Kurtosis tests) ----------
   r = stats::residuals(model)
-  
+
   # 1.1. Normality ----------
   data_ggplot_normality = data.frame(r)
   data_ggplot_skewness_test = agricolae::skewness(r)
   data_ggplot_kurtosis_test = agricolae::kurtosis(r)
-  
+
   # 1.2. Standardized residuals vs theoretical quantiles ----------
   s = sqrt(deviance(model)/stats::df.residual(model))
   rs = r/s
   data_ggplot_qqplot = data.frame(x = qnorm(ppoints(rs)), y = sort(rs))
-  
+
   # Test for homogeneity of variances
   #ft = fligner.test(variable ~ interaction(germplasm,location), data=data)
   #print(ft)
-  
+
   # 2. repartition of variability among factors ----------
   total_Sum_Sq = sum(anova_model$"Sum Sq")
   Sum_sq = anova_model$"Sum Sq"
@@ -717,11 +717,11 @@ check_freq_anova = function(model){
   percentage_Sum_sq = Sum_sq/total_Sum_Sq*100
   factor = rownames(anova_model)
   data_ggplot_variability_repartition_pie = cbind.data.frame(factor, pvalue, Sum_sq, percentage_Sum_sq)
-  
+
   # 3. variance intra germplasm
   var_intra = tapply(model$residuals, model$model$germplasm, var, na.rm = TRUE)
   data_ggplot_var_intra = data.frame(x = model$model$germplasm, y = model$residuals)
-  
+
   data_ggplot = list(
       "data_ggplot_residuals" = list(
         "data_ggplot_normality" = data_ggplot_normality,
@@ -732,7 +732,7 @@ check_freq_anova = function(model){
       "data_ggplot_variability_repartition_pie" = data_ggplot_variability_repartition_pie,
       "data_ggplot_var_intra" = data_ggplot_var_intra
     )
-  
+
   return(data_ggplot)
 }
 
@@ -743,33 +743,33 @@ check_freq_anova = function(model){
 #' @export
 #' @import ggplot2
 plot_check_freq_anova = function(x, variable){
-  r = y = percentage_Sum_sq = NULL # to avoid no visible binding for global variable 
-  
+  r = y = percentage_Sum_sq = NULL # to avoid no visible binding for global variable
+
   data_ggplot = x$data_ggplot
-  
+
   data_ggplot_normality = data_ggplot$data_ggplot_residuals$data_ggplot_normality
   data_ggplot_skewness_test = data_ggplot$data_ggplot_residuals$data_ggplot_skewness_test
   data_ggplot_kurtosis_test = data_ggplot$data_ggplot_residuals$data_ggplot_kurtosis_test
   data_ggplot_qqplot = data_ggplot$data_ggplot_residuals$data_ggplot_qqplot
   data_ggplot_variability_repartition_pie = data_ggplot$data_ggplot_variability_repartition_pie
   data_ggplot_var_intra = data_ggplot$data_ggplot_var_intra
-  
+
   # 1. Normality ----------
   # 1.1. Histogram ----------
   p = ggplot(data_ggplot_normality, aes(x = r), binwidth = 2)
   p = p + geom_histogram() + geom_vline(xintercept = 0)
   p = p + ggtitle("Test for normality", paste("Skewness:", signif(data_ggplot_skewness_test, 3), "; Kurtosis:", signif(data_ggplot_kurtosis_test, 3)))
   p1.1 = p + theme(plot.title=element_text(hjust=0.5))
-  
+
   # 1.2. Standardized residuals vs theoretical quantiles ----------
-  p = ggplot(data_ggplot_qqplot, aes(x = x, y = y)) + geom_point() + geom_line() 
+  p = ggplot(data_ggplot_qqplot, aes(x = x, y = y)) + geom_point() + geom_line()
   p = p + geom_abline(slope = 1, intercept = 0, color = "red")
   p = p + xlab("Theoretical Quantiles") + ylab("Standardized residuals")
   p1.2 = p + ggtitle("QQplot") + theme(plot.title=element_text(hjust=0.5))
-  
+
   # 2. repartition of variability among factors ----------
-  p = ggplot(data_ggplot_variability_repartition_pie, 
-             aes(x = "", y = percentage_Sum_sq, fill = factor, 
+  p = ggplot(data_ggplot_variability_repartition_pie,
+             aes(x = "", y = percentage_Sum_sq, fill = factor,
                  label = paste(round(percentage_Sum_sq, 1), "%", sep = "")
                  )
   )
@@ -777,14 +777,14 @@ plot_check_freq_anova = function(x, variable){
   p = p + geom_bar(width = 1, stat = "identity") + coord_polar("y", start = 0)
   p = p + geom_text(position = position_stack(vjust = 0.5))
   p2 = p + ylab("") + xlab("") + theme(plot.title=element_text(hjust=0.5))
-  
-  
+
+
   # 3. variance intra germplasm
   p = ggplot(data_ggplot_var_intra, aes(x = x, y = y))  + geom_boxplot(aes(color=x))
   p = p + ggtitle("Distribution of residuals") + xlab("germplasm") + ylab(variable)
   p = p + theme(legend.position = "none", axis.text.x = element_text(angle = 90), plot.title=element_text(hjust=0.5))
-  p3 = p 
-  
+  p3 = p
+
   # 4. return results
   out = list(
     "residuals" = list(
@@ -793,13 +793,13 @@ plot_check_freq_anova = function(x, variable){
     "variability_repartition" = p2,
     "variance_intra_germplasm" = p3
   )
-  
+
   return(out)
 }
 
 
 # mean_comparisons_freq_anova ----------
-#' mean comparisons for frequentist analysis 
+#' mean comparisons for frequentist analysis
 #' @param model anova model
 #' @param variable variable
 #' @param alpha alpha
@@ -807,32 +807,32 @@ plot_check_freq_anova = function(x, variable){
 #' @param info info from mean_comparisons
 #' @export
 #' @import agricolae
-mean_comparisons_freq_anova = function(model, variable, alpha = 0.05, 
+mean_comparisons_freq_anova = function(model, variable, alpha = 0.05,
                                        p.adj = "none", info = NULL,
                                        vec_fac = c("germplasm", "location", "year")
                                        ){
 
   data_ggplot_LSDbarplot = function(model, fac, p.adj, alpha){
     lsd = agricolae::LSD.test(model, fac, alpha = alpha, p.adj = p.adj)
-    
+
     parameter = factor(rownames(lsd$groups), levels = rownames(lsd$groups))
     means = lsd$groups[,1]
     groups = lsd$groups[,2]
     alpha = rep(alpha, length(parameter))
     alpha.correction = rep(p.adj, length(parameter))
-    
+
     out_LSD = data.frame(parameter, means, groups, alpha, alpha.correction)
     if( nrow(out_LSD) == 0 ) { out_LSD = NULL }
     return(out_LSD)
   }
-  
+
   # vec_fac = attr(model$terms,"term.labels")
   out = list()
   for(fac in vec_fac){
     out = c(out, list(data_ggplot_LSDbarplot(model, fac, p.adj, alpha)))
   }
   names(out) = paste("data_ggplot_LSDbarplot_", vec_fac, sep = "")
-  
+
   # Return results
   out <- c(list("info" = info), out)
 
@@ -840,7 +840,7 @@ mean_comparisons_freq_anova = function(model, variable, alpha = 0.05,
 }
 
 # plot_mean_comparisons_freq_anova ----------
-#' plot mean comparisons for frequentist analysis 
+#' plot mean comparisons for frequentist analysis
 #' @param x output from mean comparison
 #' @param variable variable
 #' @param nb_parameters_per_plot nb paramter per plot
@@ -849,19 +849,19 @@ mean_comparisons_freq_anova = function(model, variable, alpha = 0.05,
 #' @import dplyr
 #' @import plyr
 plot_mean_comparisons_freq_anova = function(x, variable, nb_parameters_per_plot = 8){
-  
+
   data_ggplot_LSDbarplot_germplasm = x$data_ggplot_LSDbarplot_germplasm
   data_ggplot_LSDbarplot_location = x$data_ggplot_LSDbarplot_location
   data_ggplot_LSDbarplot_year = x$data_ggplot_LSDbarplot_year
-  
+
   ggplot_LSDbarplot = function(d_LSD, fac, variable, nb_parameters_per_plot){
     parameter = means  = NULL  # to avoid no visible binding for global variable
-    
-    d_LSD = dplyr::arrange(d_LSD, means) 
+
+    d_LSD = dplyr::arrange(d_LSD, means)
     d_LSD$max = max(d_LSD$means, na.rm = TRUE)
     d_LSD$split = add_split_col(d_LSD, nb_parameters_per_plot)
-    d_LSD_split = plyr:::splitter_d(d_LSD, .(split))  
-    
+    d_LSD_split = plyr:::splitter_d(d_LSD, .(split))
+
     out = lapply(d_LSD_split, function(dx){
       p = ggplot(dx, aes(x = reorder(parameter, means), y = means)) + geom_bar(stat = "identity")
       p = p + geom_text(aes(x = reorder(parameter, means), y = means/2, label = groups), angle = 90, color = "white")
@@ -869,43 +869,43 @@ plot_mean_comparisons_freq_anova = function(x, variable, nb_parameters_per_plot 
       p = p + xlab("") + theme(axis.text.x = element_text(angle = 90)) + coord_cartesian(ylim = c(0, dx[1,"max"])) + ylab(variable)
       return(p)
     })
-    
+
     return(out)
   }
-  
+
   # Germplasm
-  if( !is.null(data_ggplot_LSDbarplot_germplasm) ){ 
-    ggplot_LSDbarplot_germplasm = ggplot_LSDbarplot(data_ggplot_LSDbarplot_germplasm, "germplasm", variable, nb_parameters_per_plot) 
+  if( !is.null(data_ggplot_LSDbarplot_germplasm) ){
+    ggplot_LSDbarplot_germplasm = ggplot_LSDbarplot(data_ggplot_LSDbarplot_germplasm, "germplasm", variable, nb_parameters_per_plot)
   } else {
     ggplot_LSDbarplot_germplasm = NULL
   }
-  
+
   # Location
-  if( !is.null(data_ggplot_LSDbarplot_location) ){ 
-    ggplot_LSDbarplot_location = ggplot_LSDbarplot(data_ggplot_LSDbarplot_location, "location", variable, nb_parameters_per_plot) 
+  if( !is.null(data_ggplot_LSDbarplot_location) ){
+    ggplot_LSDbarplot_location = ggplot_LSDbarplot(data_ggplot_LSDbarplot_location, "location", variable, nb_parameters_per_plot)
   } else {
     ggplot_LSDbarplot_location = NULL
   }
-  
+
   # Year
-  if( !is.null(data_ggplot_LSDbarplot_year) ){ 
-    ggplot_LSDbarplot_year = ggplot_LSDbarplot(data_ggplot_LSDbarplot_year, "year", variable, nb_parameters_per_plot) 
+  if( !is.null(data_ggplot_LSDbarplot_year) ){
+    ggplot_LSDbarplot_year = ggplot_LSDbarplot(data_ggplot_LSDbarplot_year, "year", variable, nb_parameters_per_plot)
   } else {
     ggplot_LSDbarplot_year = NULL
   }
-  
+
   # Return results
   out = list(
-    "germplasm" = ggplot_LSDbarplot_germplasm, 
-    "location" = ggplot_LSDbarplot_location, 
+    "germplasm" = ggplot_LSDbarplot_germplasm,
+    "location" = ggplot_LSDbarplot_location,
     "year" = ggplot_LSDbarplot_year
   )
-  
-  return(out) 
+
+  return(out)
 }
 
 # pmap -----
-#' map background for plot.data_agro, plot.data_network 
+#' map background for plot.data_agro, plot.data_network
 #' @param net network object or data frame
 #' @param format network format
 #' @param labels_on where display label
@@ -917,27 +917,27 @@ plot_mean_comparisons_freq_anova = function(x, variable, nb_parameters_per_plot 
 #' @import intergraph
 #' @import png
 #' @import grid
-#' 
+#'
 pmap = function(net, format, labels_on, labels_size, zoom){
   wt = mpg = long = lat  = NULL  # to avoid no visible binding for global variable
-  
+
   # As it is not possible to use annotation_custom with polar coordinates (i.e. output from ggmap) in order to add pies on map,
   # I decided to transfer ggmap output to a png that is inserted in a background of a plot with cartesian coordinates
   # Note there is a change in the look of the map because of coordinates change ...
   if( is_igraph(net) ){
     d = ggnetwork::ggnetwork(net, arrow.gap = 0)
-    
+
     if( format == "bipart" ) {
       d = d[which(d$type == "location"), c("lat", "long", "vertex.names")]
       colnames(d)[ncol(d)] = "location"
-    } 
+    }
     if( format == "unipart_location" ){
       d = d[c("lat", "long", "vertex.names")]
       colnames(d)[ncol(d)] = "location"
     }
   } else { d = net }
 
-  n = unique(d[, c("lat", "long", "location")]) 
+  n = unique(d[, c("lat", "long", "location")])
   n$lat = as.numeric(as.character(n$lat))
   n$long = as.numeric(as.character(n$long))
   n = na.omit(n)
@@ -948,13 +948,13 @@ pmap = function(net, format, labels_on, labels_size, zoom){
   p = ggplot() # support for the map background
   p = p + coord_cartesian(xlim = range(m$data$lon), ylim = range(m$data$lat), expand = FALSE)
   img = png::readPNG("tmp_map.png")
-  pmap = p + annotation_custom(grid::rasterGrob(img, width = unit(1,"npc"), height = unit(1,"npc")), 
+  pmap = p + annotation_custom(grid::rasterGrob(img, width = unit(1,"npc"), height = unit(1,"npc")),
                                -Inf, Inf, -Inf, Inf) # change in the look of the map because of coordinates changes
   pmap = pmap + xlab("long") + ylab("lat")
   file.remove("tmp_map.png")
   if( !is.null(labels_on) ){
-    if( labels_on == "location" ){ 
-      pmap = pmap + geom_nodelabel_repel(data = n, aes(x = long, y = lat, label = location), size = labels_size, inherit.aes = FALSE) 
+    if( labels_on == "location" ){
+      pmap = pmap + geom_nodelabel_repel(data = n, aes(x = long, y = lat, label = location), size = labels_size, inherit.aes = FALSE)
     }
   }
   return(pmap)
@@ -971,14 +971,14 @@ pmap = function(net, format, labels_on, labels_size, zoom){
 #' @param variable variable to display
 #' @param pie_size size of the pie
 #' @details
-#' script adapted from 
-#' Pies On A Map, Demonstration script, By QDR : 
+#' script adapted from
+#' Pies On A Map, Demonstration script, By QDR :
 #' https://qdrsite.wordpress.com/2016/06/26/pies-on-a-map/
-#' 
+#'
 #' Guangchuang YU code :
 #' https://cran.r-project.org/web/packages/ggimage/vignettes/ggimage.html#geom_subview
 #' https://github.com/GuangchuangYu/ggimage/blob/master/R/geom_subview.R
-#' 
+#'
 #' @export
 #' @importFrom ggimage geom_subview
 #' @import plyr
@@ -986,48 +986,48 @@ pmap = function(net, format, labels_on, labels_size, zoom){
 #' @import intergraph
 #' @import ggplot2
 #' @import igraph
-#' 
+#'
 add_pies = function(p, n, format, plot_type, data_to_pie, variable, pie_size){
-  
+
   id_ok = NULL # to avoid no visible binding for global variable ‘id_ok’
-  
+
   # add a invisible point with variable value to get the legend of pies + set the legend
   colnames(data_to_pie)[which(colnames(data_to_pie) == variable)] = "variable"
-  
+
   col_low = "red" # "#132B43"
   col_high = "green" # "#56B1F7"
-  
-  if( is.numeric(data_to_pie$variable) ) {  
+
+  if( is.numeric(data_to_pie$variable) ) {
     p = p + geom_point(data = data_to_pie, x = 0, y = 0, size = -10, aes(fill = variable), inherit.aes = FALSE)
     p = p + scale_fill_continuous(low = col_low, high = col_high)
     scale_ok = scales::seq_gradient_pal(low = col_low, high = col_high)(seq(0, 1, length.out = nrow(data_to_pie)))
     s = seq(min(data_to_pie$variable, na.rm = TRUE), max(data_to_pie$variable, na.rm = TRUE), length.out = nrow(data_to_pie))
     data_to_pie$scale_col = sapply(data_to_pie$variable, function(x){scale_ok[which(s >= x)[1]]})
   }
-  
-  if( is.factor(data_to_pie$variable) ) {  
-    p = p + geom_point(data = data_to_pie, x = -10, y = 10, aes(shape = variable, fill = variable), inherit.aes = FALSE) 
+
+  if( is.factor(data_to_pie$variable) ) {
+    p = p + geom_point(data = data_to_pie, x = -10, y = 10, aes(shape = variable, fill = variable), inherit.aes = FALSE)
     p = p + scale_shape_manual(values = rep(22, nlevels(data_to_pie$variable)))
     scale_ok = scales::seq_gradient_pal(low = col_low, high = col_high)(seq(0, 1, length.out = nlevels(data_to_pie$variable)))
     p = p + scale_fill_manual(values = scale_ok)
     s = seq(1, nlevels(data_to_pie$variable))
     data_to_pie$scale_col = sapply(as.numeric(data_to_pie$variable), function(x){scale_ok[which(s >= x)[1]]})
   }
-  
-  
+
+
   # Set colnames for next step according to plot type and get range for x and y
-  if( plot_type == "map" ) { 
-    colnames(data_to_pie)[which(colnames(data_to_pie) == "location")] = "id_ok" 
+  if( plot_type == "map" ) {
+    colnames(data_to_pie)[which(colnames(data_to_pie) == "location")] = "id_ok"
     xmin = min(p$coordinates$limits$x); xmax = max(p$coordinates$limits$x)
     ymin = min(p$coordinates$limits$y); ymax = max(p$coordinates$limits$y)
   }
-  
-  if( plot_type == "network" ){ 
-    colnames(data_to_pie)[which(colnames(data_to_pie) == "id")] = "id_ok" 
+
+  if( plot_type == "network" ){
+    colnames(data_to_pie)[which(colnames(data_to_pie) == "id")] = "id_ok"
     xmin = min(p$data$x); xmax = max(p$data$x)
     ymin = min(p$data$y); ymax = max(p$data$y)
   }
-  
+
   # Create a list of ggplot objects. Each one is the pie chart for each site with all labels removed.
   pies <- plyr::dlply(data_to_pie, .(id_ok), function(z){
     z = dplyr::arrange(z, variable)
@@ -1048,71 +1048,71 @@ add_pies = function(p, n, format, plot_type, data_to_pie, variable, pie_size){
             panel.border=element_blank(),
             panel.grid.major=element_blank(),
             panel.grid.minor=element_blank(),
-            plot.background=element_blank()) 
+            plot.background=element_blank())
   }
   )
-  
+
   # Get coordinates of each pie and select pies
   if( igraph::is_igraph(n) ){
     d = ggnetwork::ggnetwork(n, arrow.gap = 0)
   } else { d = n }
   v_id = c(unique(as.character(data_to_pie$id_ok)))
-  
+
   if( plot_type == "map" & format == "bipart" ){
     d = droplevels(d[which(d$type == "location"),])
     v_ok = v_id[which(is.element(v_id, as.character(d$vertex.names) ))]
     v_not_ok = v_id[which(!is.element(v_id, as.character(d$vertex.names) ))]
-  } 
+  }
   if( plot_type == "map" & format == "unipart_location" ){
     v_ok = v_id[which(is.element(v_id, as.character(d$vertex.names) ))]
     v_not_ok = v_id[which(!is.element(v_id, as.character(d$vertex.names) ))]
-  } 
+  }
   if( plot_type == "map" & format == "unipart_sl" ){
     v_ok = v_id[which(is.element(v_id, as.character(d$location) ))]
     v_not_ok = v_id[which(!is.element(v_id, as.character(d$location) ))]
-  }    
+  }
   if( plot_type == "network" & format == "unipart_sl" ){
     v_ok = v_id[which(is.element(v_id, as.character(d$vertex.names) ))]
     v_not_ok = v_id[which(!is.element(v_id, as.character(d$vertex.names) ))]
-  } 
+  }
   if( plot_type == "map" & format == "data_agro" ){
     v_ok = v_id[which(is.element(v_id, as.character(d$location) ))]
     v_not_ok = v_id[which(!is.element(v_id, as.character(d$location) ))]
-  }    
+  }
   pies = pies[v_ok]
-  
-  if( length(v_ok) == 0) { 
-    warning("In the data with the variable, no id exist in the data with coordinates and therefore no pies are displayed") 
+
+  if( length(v_ok) == 0) {
+    warning("In the data with the variable, no id exist in the data with coordinates and therefore no pies are displayed")
   }
-  if( length(v_ok) < length(v_id) ){ 
-    warning("In the data with the variable, the following id does not exist in the data with the coordinates: ", paste(v_not_ok, collapse = ", ")) 
+  if( length(v_ok) < length(v_id) ){
+    warning("In the data with the variable, the following id does not exist in the data with the coordinates: ", paste(v_not_ok, collapse = ", "))
   }
-  
-  if( plot_type == "map" ){ 
+
+  if( plot_type == "map" ){
     if( length(v_ok) > 0 ) {
       if( format == "bipart" ) {
         d = ggnetwork::ggnetwork(n, arrow.gap = 0)
         d = d[which(d$type == "location"), c("lat", "long", "vertex.names")]
         colnames(d)[ncol(d)] = "location"
-      } 
+      }
       if( format == "unipart_location" ){
         d = ggnetwork::ggnetwork(n, arrow.gap = 0)
         d = d[c("lat", "long", "vertex.names")]
         colnames(d)[ncol(d)] = "location"
       }
       d = unique(d[, c("lat", "long", "location")])
-      
+
       piecoords = lapply(names(pies), function(x){
-        c(x = as.numeric(as.character(d[which(d$location == x), "long"])), 
+        c(x = as.numeric(as.character(d[which(d$location == x), "long"])),
           y = as.numeric(as.character(d[which(d$location == x), "lat"]))
         )
-      } 
+      }
       )
     }
   }
-  
-  
-  if( plot_type == "network" ){ 
+
+
+  if( plot_type == "network" ){
     if( length(v_ok) > 0 ) {
       piecoords = lapply(names(pies), function(x){
         c(x = unique(p$data[which(p$data$vertex.names == x), "x"]), y = unique(p$data[which(p$data$vertex.names == x), "y"]))
@@ -1120,18 +1120,18 @@ add_pies = function(p, n, format, plot_type, data_to_pie, variable, pie_size){
       )
     }
   }
-  
+
   # add pies on plot
   if( length(v_ok) > 0 ) {
     for(i in 1:length(pies)){
-      p = p + geom_subview(x = piecoords[[i]]["x"], y = piecoords[[i]]["y"], 
-                           subview = pies[[i]], 
+      p = p + geom_subview(x = piecoords[[i]]["x"], y = piecoords[[i]]["y"],
+                           subview = pies[[i]],
                            width = (xmax-xmin)*pie_size, height = (ymax-ymin)*pie_size)
       # p = p + labs(fill = variable) # not good with factor variables ...
       p = p + ggtitle(variable)
     }
   }
-  
+
   return(p)
 }
 
@@ -1139,30 +1139,30 @@ add_pies = function(p, n, format, plot_type, data_to_pie, variable, pie_size){
 #' format data for organoleptic analysis
 #' @param data data frame
 #' @param threshold threshold
-#' @details see \code{\link{format_data_PPBstats.data_organo_napping}} and 
+#' @details see \code{\link{format_data_PPBstats.data_organo_napping}} and
 #' \code{\link{format_data_PPBstats.data_organo_hedonic}}
 #' @export
 format_organo = function(data, threshold){
   # 1. Merge and create data frame ----------
   N = data
   N$sample = factor(paste(N$location, N$germplasm, sep = ":"))
-  
+
   # 2. Add the occurence of the different descriptors ----------
   descriptors = as.vector(as.character(N$descriptors))
   vec_adj = unlist(strsplit(descriptors, ";"))
   vec_adj = sort(unique(vec_adj))
   if( length(which(vec_adj == "")) > 0 ) { vec_adj = vec_adj[-which(vec_adj == "")] }
-  
+
   df = matrix(0, ncol = length(vec_adj), nrow = nrow(N))
   df = as.data.frame(df)
   colnames(df) = vec_adj
   out = cbind.data.frame(N, df)
-  
+
   for (i in 1:nrow(out)){
     v_adj = out[i, "descriptors"]
     v_adj = unlist(strsplit(as.character(v_adj), ";"))
     if( length(which(v_adj == "")) > 0 ) { v_adj = v_adj[-which(v_adj == "")] }
-    
+
     for (j in 1:length(v_adj)) {
       e = v_adj[j]
       if (length(e)>0) {
@@ -1170,33 +1170,33 @@ format_organo = function(data, threshold){
       }
     }
   }
-  
+
   N = out[,-which(colnames(out) == "descriptors")]
-  
+
   # 3. Apply the threshold to keep certain descriptors ----------
   if( !is.null(threshold) ) {
     test = apply(N[, vec_adj], 2, sum)
     to_delete = which(test <= threshold)
     to_keep = which(test > threshold)
-    if( length(to_delete) > 0 ) { 
-      adj_to_delete = vec_adj[to_delete] 
+    if( length(to_delete) > 0 ) {
+      adj_to_delete = vec_adj[to_delete]
       N = N[,-which(colnames(N) %in% adj_to_delete)]
       message("The following descriptors have been remove because there were less or equal to ", threshold, " occurences : ", paste(adj_to_delete, collapse = ", "))
-      if( ncol(N) == 4 ){ stop("There are no more descriptors with threshold = ", threshold, 
+      if( ncol(N) == 4 ){ stop("There are no more descriptors with threshold = ", threshold,
                                ". You must set another value.") }
     }
     vec_adj = vec_adj[to_keep]
   }
-  
-  
+
+
   # 4. Get frequency for each descriptor ----------
   N_freq = N_raw = N
-  for (ad in vec_adj) { 
-    if( sum(N_raw[, ad], na.rm = TRUE) != 0 ) { 
-      N_freq[, ad] = N_raw[, ad] / sum(N_raw[, ad], na.rm = TRUE) 
-    }  
+  for (ad in vec_adj) {
+    if( sum(N_raw[, ad], na.rm = TRUE) != 0 ) {
+      N_freq[, ad] = N_raw[, ad] / sum(N_raw[, ad], na.rm = TRUE)
+    }
   }
-  
+
   return(N_freq)
 }
 
@@ -1205,11 +1205,11 @@ format_organo = function(data, threshold){
 #'
 #' @description
 #' \code{plot_descriptive_data} gets ggplot to describe the data
-#' 
+#'
 #' @param x The data frame. It should come from \code{\link{format_data_PPBstats}}
-#' 
+#'
 #' @param data_version data frame coming from \code{\link{format_data_PPBstats.data_agro_version}}
-#' 
+#'
 #' @param plot_type the type of plot you wish. It can be :
 #' \itemize{
 #'  \item "pam" for presence abscence matrix that represent the combinaison of germplasm x location
@@ -1222,55 +1222,55 @@ format_organo = function(data, threshold){
 #'  \item "raster"
 #'  \item "map"
 #' }
-#' 
-#' @param x_axis factor displayed on the x.axis of a plot. 
-#' "date_julian" can be choosen: it will  display julian day for a given variable automatically calculated from format_data_PPBstats(). 
+#'
+#' @param x_axis factor displayed on the x.axis of a plot.
+#' "date_julian" can be choosen: it will  display julian day for a given variable automatically calculated from format_data_PPBstats().
 #' This is possible only for plot_type = "histogramm", "barplot", "boxplot" and "interaction".
 #' @param in_col factor displayed in color of a plot
-#' 
+#'
 #' @param vec_variables vector of variables to display
-#' 
+#'
 #' @param nb_parameters_per_plot_x_axis the number of parameters per plot on x_axis arguments
-#' 
+#'
 #' @param nb_parameters_per_plot_in_col the number of parameters per plot for in_col arguments
-#' 
+#'
 #' @param labels_on factor to display for plot_type = "biplot"
-#' 
+#'
 #' @param labels_size size of the label for plot_type = "biplot" and "radar"
-#' 
-#' @param pie_size when plot_type = "map" and vec_variables is not NULL, size of the pie 
-#' 
+#'
+#' @param pie_size when plot_type = "map" and vec_variables is not NULL, size of the pie
+#'
 #' @param zoom zoom of the map, see ?get_map for more details
-#' 
+#'
 #' @param ... further arguments passed to or from other methods
-#' 
-#' @return 
+#'
+#' @return
 #' \itemize{
 #'  \item For plot_type "histogramm", "barplot", "boxplot" or "interaction",
 #'  the function returns a list with ggplot objects for each variable of vec_variables.
 #'  \item For plot_type "biplot",
-#'  the function returns a list with ggplot objects for each pairs of variables of vec_variables. 
+#'  the function returns a list with ggplot objects for each pairs of variables of vec_variables.
 #'  \item For plot_type "radar" and "raster,
-#'  the function returns a list with ggplot objects with all variables of vec_variables. 
-#'  \item For plot_type "map", it returns a map with location 
+#'  the function returns a list with ggplot objects with all variables of vec_variables.
+#'  \item For plot_type "map", it returns a map with location
 #'  if vec_variables = NULL and labels_on = "location".
 #'  If vec_variables is not NULL, it displays pie on map.
 #' }
-#' Each list is divided in several lists according to values 
+#' Each list is divided in several lists according to values
 #' of nb_parameters_per_plot_x_axis and nb_parameters_per_plot_in_col except for plot_type = "map".
-#' 
+#'
 #' @author Pierre Riviere
-#' 
-#' @details 
+#'
+#' @details
 #' S3 method.
-#' 
+#'
 #' @seealso \code{\link{format_data_PPBstats}}
-#' 
+#'
 #' @export
-#' 
+#'
 #' @import ggplot2
 #' @import plyr
-#' 
+#'
 plot_descriptive_data = function(
   x,
   data_version = NULL,
@@ -1285,111 +1285,111 @@ plot_descriptive_data = function(
   pie_size = 0.2,
   zoom = 6, ...
 ){
-  
+
   data = x
-  
-  # 1. Error message ----------  
+
+  # 1. Error message ----------
   mess = "plot_type must be \"pam\", \"histogramm\", \"barplot\", \"boxplot\", \"interaction\", \"biplot\", \"radar\", \"raster\" or \"map\"."
   if(length(plot_type) != 1) { stop(mess) }
-  if(!is.element(plot_type, c("pam", "histogramm", "barplot", "boxplot", "interaction", "biplot", "radar", "raster", "map"))) { 
-    stop(mess) 
+  if(!is.element(plot_type, c("pam", "histogramm", "barplot", "boxplot", "interaction", "biplot", "radar", "raster", "map"))) {
+    stop(mess)
   }
-  
+
   if(is.null(vec_variables) & plot_type != "map"){ stop("You must settle vec_variables") }
-  
-  check_arg = function(x, vec_x) { 
-    for(i in x) { 
-      if(!is.element(i, vec_x)) { 
-        stop("Regarding ", substitute(x),", ", i," is not in data") 
-      } 
-    } 
-  }
-  
-  if(!is.null(x_axis)){ 
-    if( x_axis != "date_julian") { 
-      check_arg(x_axis, colnames(data)) 
-    } else { 
-      warning("x_axis = \"date_julian\" is a special feature that will display julian day for a given variable automatically calculated from format_data_PPBstats().") 
-      if(!is.element(plot_type, c("histogramm", "barplot", "boxplot", "interaction"))){ 
-        stop("x_axis = \"date_julian\" is possible only for plot_type = \"histogramm\", \"barplot\", \"boxplot\" and \"interaction\".") 
+
+  check_arg = function(x, vec_x) {
+    for(i in x) {
+      if(!is.element(i, vec_x)) {
+        stop("Regarding ", substitute(x),", ", i," is not in data")
       }
     }
   }
-  
+
+  if(!is.null(x_axis)){
+    if( x_axis != "date_julian") {
+      check_arg(x_axis, colnames(data))
+    } else {
+      warning("x_axis = \"date_julian\" is a special feature that will display julian day for a given variable automatically calculated from format_data_PPBstats().")
+      if(!is.element(plot_type, c("histogramm", "barplot", "boxplot", "interaction"))){
+        stop("x_axis = \"date_julian\" is possible only for plot_type = \"histogramm\", \"barplot\", \"boxplot\" and \"interaction\".")
+      }
+    }
+  }
+
   if(!is.null(in_col)){ check_arg(in_col, colnames(data)) }
   check_arg(vec_variables, colnames(data))
   if(!is.null(labels_on)){ check_arg(labels_on, colnames(data)) }
-  
-  if( plot_type == "pam" & (!is.null(x_axis) | !is.null(in_col)) ){ 
+
+  if( plot_type == "pam" & (!is.null(x_axis) | !is.null(in_col)) ){
     warning("Note than with plot_type == pam, x_axis and in_col are not used.")
   }
-  if( plot_type == "histogramm" & !is.null(x_axis) ){ 
+  if( plot_type == "histogramm" & !is.null(x_axis) ){
     warning("Note than with plot_type == histogramm, x_axis can not be NULL.")
   }
-  if( plot_type == "barplot" & is.null(x_axis) & is.null(data_version) ){ 
+  if( plot_type == "barplot" & is.null(x_axis) & is.null(data_version) ){
     stop("With plot_type == barplot, x_axis can not be NULL.")
   }
-  if( plot_type == "boxplot" & is.null(x_axis)  & is.null(data_version) ){ 
+  if( plot_type == "boxplot" & is.null(x_axis)  & is.null(data_version) ){
     stop("With plot_type == boxplot, x_axis can not be NULL.")
   }
-  if( plot_type == "interaction" & (is.null(x_axis) | is.null(in_col)) ){ 
+  if( plot_type == "interaction" & (is.null(x_axis) | is.null(in_col)) ){
     stop("With plot_type == interaction, x_axis and in_col can not be NULL.")
   }
-  if( plot_type == "biplot" & !is.null(x_axis) ){ 
+  if( plot_type == "biplot" & !is.null(x_axis) ){
     warning("Note than with plot_type == biplot, x_axis is not used can not be NULL.")
   }
-  if( plot_type == "biplot" & length(vec_variables) < 2 ){ 
+  if( plot_type == "biplot" & length(vec_variables) < 2 ){
     stop("With plot_type == biplot, vec_variables must have at least 2 elements.")
   }
-  if( plot_type == "biplot" & is.null(labels_on) ){ 
+  if( plot_type == "biplot" & is.null(labels_on) ){
     stop("With plot_type == biplot, labels_on can not be NULL.")
   }
-  if( plot_type == "biplot" & length(labels_on) != 1 ){ 
+  if( plot_type == "biplot" & length(labels_on) != 1 ){
     stop("labels_on must be of length one..")
   }
-  if( plot_type == "radar" & length(vec_variables) < 2 ){ 
+  if( plot_type == "radar" & length(vec_variables) < 2 ){
     stop("With plot_type == radar, vec_variables must have at least 2 elements.")
   }
-  if( plot_type == "radar" & is.null(in_col) ){ 
+  if( plot_type == "radar" & is.null(in_col) ){
     stop("With plot_type == radar, in_col must not be NULL.")
   }
-  if( plot_type == "radar" & !is.null(labels_on) ){ 
+  if( plot_type == "radar" & !is.null(labels_on) ){
     warning("Note that with plot_type == radar, labels_on is not used.")
   }
-  
-  if( plot_type == "raster" & !is.null(in_col) ){ 
+
+  if( plot_type == "raster" & !is.null(in_col) ){
     warning("Note that with plot_type == raster, in_col is not used.")
   }
-  if( plot_type == "raster" & !is.null(labels_on) ){ 
+  if( plot_type == "raster" & !is.null(labels_on) ){
     warning("Note that with plot_type == raster, labels_on is not used.")
   }
-  
+
   if( plot_type == "map" ){
     test = unique(is.element(c("lat", "long"), colnames(data)))
     if( length(test) == 2 | !test[1] ){ stop("To display map, you must have columns \"lat\" and \"long\" in your data.") }
   }
-  
+
   if( !is.null(data_version) ){
     if( !is.element(plot_type, c("barplot", "boxplot")) ){ stop("With data_version, only plot_type \"barplot\" and \"boxplot\" are possible.") }
   }
-  
+
   # 2. Functions used in the newt steps ----------
-  
+
   # 2.1. Function to run presence abscence matrix ----------
   fun_pam = function(data, vec_variables){
-    
+
     fun_pam_1 = function(variable, data){
       nb_measures = germplasm = NULL  # to avoid no visible binding for global variable
-      
+
       dtmp = droplevels(na.omit(data[,c("germplasm", "location", "year", variable)]))
       dtmp[,variable] = as.numeric(dtmp[,variable])
-      
+
       xlim = c(min(dtmp[,variable], na.rm = TRUE), max(dtmp[,variable], na.rm = TRUE))
       ylim = c(0,max(dtmp[,variable], na.rm = TRUE))
       m = as.data.frame(with(dtmp, table(germplasm, location, year)))
       m$Freq = as.factor(m$Freq)
       colnames(m)[4] = "nb_measures"
-      
+
       p = ggplot(m, aes(x = germplasm, y = location))
       p = p + geom_raster(aes(fill = nb_measures)) + facet_grid(year ~ .)
       nb_NA = round(length(which(m$nb_measures == 0)) / ( length(which(m$nb_measures == 0)) + length(which(m$nb_measures != 0)) ), 2) * 100
@@ -1403,89 +1403,89 @@ plot_descriptive_data = function(
     names(out) = vec_variables
     return(out)
   }
-  
-  
+
+
   # 2.2. Function to run histogramm, barplot, boxplot, interaction ----------
   fun_hbbi_1 = function(d, x_axis, in_col, plot_type, variable, ylim){
-    
+
     d$variable = d[,variable]
-    
+
     # histogramm
     if(plot_type == "histogramm") {
       p = ggplot(d, aes( x = variable))
-      if( is.null(in_col) ) { 
-        p = p + geom_histogram() 
-      } else { 
-        p = p + geom_histogram(aes(fill = in_col)) 
+      if( is.null(in_col) ) {
+        p = p + geom_histogram()
+      } else {
+        p = p + geom_histogram(aes(fill = in_col))
       }
     }
-    
+
     # barplot
-    if(plot_type == "barplot") {	
-      if(is.null(in_col)) {	
+    if(plot_type == "barplot") {
+      if(is.null(in_col)) {
         mm2 = plyr::ddply(d, "x_axis", summarise, mean = mean(variable, na.rm = TRUE), sd = sd(variable, na.rm = TRUE))
-        p = ggplot(mm2, aes(x = x_axis, y = mean)) + geom_bar(stat = "identity") 
+        p = ggplot(mm2, aes(x = x_axis, y = mean)) + geom_bar(stat = "identity")
         limits <- aes(ymax = mean + sd, ymin = mean - sd)
         p = p + geom_errorbar(limits, position = position_dodge(width=0.9), width=0.25)
       } else {
         d$toto = paste(d$in_col, d$x_axis, sep = "azerty")
-        mm = ddply(d, "toto", summarise, mean = mean(variable, na.rm = TRUE), sd = sd(variable, na.rm = TRUE)) 
+        mm = ddply(d, "toto", summarise, mean = mean(variable, na.rm = TRUE), sd = sd(variable, na.rm = TRUE))
         mm$in_col = as.factor(sapply(mm$toto, function(x){unlist(strsplit(x, "azerty"))[1]}))
         mm$x_axis = as.factor(sapply(mm$toto, function(x){unlist(strsplit(x, "azerty"))[2]}))
-        
+
         p = ggplot(mm, aes(x = x_axis, y = mean, fill = in_col))
-        p = p + geom_bar(position = "dodge", stat = "identity") 
+        p = p + geom_bar(position = "dodge", stat = "identity")
         limits <- aes(ymax = mean + sd, ymin = mean - sd)
         p = p + geom_errorbar(limits, position = position_dodge(width=0.9), width=0.25)
       }
     }
-    
-    
+
+
     # boxplot
     if(plot_type == "boxplot") {
       p = ggplot(d, aes( x = x_axis, y = variable))
-      if( is.null(in_col) ) { 
-        p = p + geom_boxplot(position="dodge") 
-      } else { 
-        p = p + geom_boxplot(aes(fill = in_col)) 
+      if( is.null(in_col) ) {
+        p = p + geom_boxplot(position="dodge")
+      } else {
+        p = p + geom_boxplot(aes(fill = in_col))
       }
     }
-    
+
     # interaction
-    if(plot_type == "interaction") {										
+    if(plot_type == "interaction") {
       p = ggplot(d, aes(y = variable, x = factor(x_axis), colour = factor(in_col), group = factor(in_col)))
       p = p + stat_summary(fun.y = mean, geom = "point") + stat_summary(fun.y = mean, geom = "line")
     }
-    
+
     if(is.element(plot_type, c("barplot", "boxplot", "interaction"))) {
-      p = p + xlab("") + ylab(variable) + theme(axis.text.x = element_text(angle = 90, hjust = 1), legend.title = element_blank())	
+      p = p + xlab("") + ylab(variable) + theme(axis.text.x = element_text(angle = 90, hjust = 1), legend.title = element_blank())
       p = p + coord_cartesian(xlim = NULL, ylim)
     }
-    
+
     return(p)
   }
-  
+
   fun_hbbi = function(d, vec_variables,
-                      x_axis, nb_parameters_per_plot_x_axis, 
-                      in_col, nb_parameters_per_plot_in_col, 
-                      plot_type){ 
-    
-    out = lapply(vec_variables, 
+                      x_axis, nb_parameters_per_plot_x_axis,
+                      in_col, nb_parameters_per_plot_in_col,
+                      plot_type){
+
+    out = lapply(vec_variables,
                  function(variable, d, labels_on,
                           x_axis, nb_parameters_per_plot_x_axis,
                           in_col, nb_parameters_per_plot_in_col,
                           plot_type){
-                   
-                   if(!is.null(x_axis)){ 
+
+                   if(!is.null(x_axis)){
                      if( x_axis == "date_julian") { x_axis = paste(variable, "$date_julian", sep = "") }
                    }
-                   
+
                    d = reshape_data_split_x_axis_in_col(d, variable, labels_on,
                                                         x_axis, nb_parameters_per_plot_x_axis,
                                                         in_col, nb_parameters_per_plot_in_col
                    )
                    ylim = range(unlist(lapply(d, function(x){ range(x[,variable], na.omit = TRUE) } )))
-                   
+
                    out = lapply(d, fun_hbbi_1, x_axis, in_col, plot_type, variable, ylim)
                    return(out)
                  },
@@ -1497,20 +1497,20 @@ plot_descriptive_data = function(
     names(out) = vec_variables
     return(out)
   }
-  
-  
+
+
   # 2.3. Function to run biplot ----------
   fun_biplot = function(d, vec_variables, labels_on, labels_size,
-                        x_axis, nb_parameters_per_plot_x_axis, 
+                        x_axis, nb_parameters_per_plot_x_axis,
                         in_col, nb_parameters_per_plot_in_col
   ){
     labels_text = NULL  # to avoid no visible binding for global variable
-    
+
     d = reshape_data_split_x_axis_in_col(d, vec_variables, labels_on,
-                                         x_axis, nb_parameters_per_plot_x_axis, 
+                                         x_axis, nb_parameters_per_plot_x_axis,
                                          in_col, nb_parameters_per_plot_in_col
     )
-    
+
     ylim = NULL
     for(variable in vec_variables){
       ylim = c(ylim, list(
@@ -1519,33 +1519,33 @@ plot_descriptive_data = function(
       )
     }
     names(ylim) = vec_variables
-    
+
     fun_biplot_1 = function(pair_var, d, in_col, labels_size, ylim){
       fun_biplot_2 = function(d, pair_var, in_col, labels_size, ylim){
         var_ = unlist(strsplit(pair_var, " -azerty- "))
         var1 = var_[1]; d$var1 = d[,var1]
         var2 = var_[2]; d$var2 = d[,var2]
         ylim = range(unlist(ylim[c(var_[1], var_[2])]))
-        if(!is.null(in_col)){ 
-          dtmp = d[,c("in_col", "var1", "var2", "labels_text")] 
+        if(!is.null(in_col)){
+          dtmp = d[,c("in_col", "var1", "var2", "labels_text")]
         } else {
-          dtmp = d[,c("var1", "var2", "labels_text")] 
+          dtmp = d[,c("var1", "var2", "labels_text")]
         }
         dtmp = na.omit(dtmp)
         if( nrow(dtmp) == 0){
-          warning("No biplot is done for ", var1, " and ", var2, " as there are only NA. This can be due to missing data."); 
+          warning("No biplot is done for ", var1, " and ", var2, " as there are only NA. This can be due to missing data.");
           p = NULL
         } else {
-          p = ggplot(dtmp, aes(x = var1, y = var2, label = labels_text)) 
+          p = ggplot(dtmp, aes(x = var1, y = var2, label = labels_text))
           if(!is.null(in_col)){
-            p = p + geom_text(aes(colour = in_col), size = labels_size)             
+            p = p + geom_text(aes(colour = in_col), size = labels_size)
           } else {
-            p = p + geom_text(size = labels_size) 
+            p = p + geom_text(size = labels_size)
           }
           p = p + coord_cartesian(xlim = NULL, ylim = ylim)
           p = p + stat_smooth(method = "lm", se = FALSE)
-          p = p  + xlab(var1) + ylab(var2) + theme(axis.text.x = element_text(angle=90, hjust=1), legend.title = element_blank()) 
-          
+          p = p  + xlab(var1) + ylab(var2) + theme(axis.text.x = element_text(angle=90, hjust=1), legend.title = element_blank())
+
           m <- lm(var2 ~ var1, dtmp)
           eq = paste("y = ", format(coef(m)[1], digits = 2), " x +", format(coef(m)[2], digits = 2), "; r2 = ", format(summary(m)$r.squared, digits = 3), sep = "")
           p = p + ggtitle(eq) + theme(plot.title = element_text(hjust = 0.5))
@@ -1555,17 +1555,17 @@ plot_descriptive_data = function(
       p = lapply(d, fun_biplot_2, pair_var, in_col, labels_size, ylim)
       return(p)
     }
-    
+
     pair_var = apply(combn(vec_variables, 2), 2, function(x){paste(x, collapse = " -azerty- ")})
     out = lapply(pair_var, fun_biplot_1, d, in_col, labels_size, ylim)
     names(out) = sub(" -azerty- ", " - ", pair_var)
     return(out)
   }
-  
+
   # 2.4. Function to run radar ----------
   fun_radar = function(d, vec_variables, in_col, labels_size){
     d$group = d[,in_col]
-    
+
     m = data.frame(matrix(levels(d$group), ncol = 1))
     for(variable in vec_variables){
       value = tapply(d[,variable], d$group, mean, na.rm = TRUE)
@@ -1574,65 +1574,65 @@ plot_descriptive_data = function(
       m = cbind.data.frame(m, value_ok)
     }
     colnames(m) = c("group", vec_variables)
-    p = ggradar(m, 
-                grid.label.size = labels_size, 
+    p = ggradar(m,
+                grid.label.size = labels_size,
                 axis.label.size = labels_size,
                 group.point.size = labels_size,
                 legend.text.size = labels_size*2.5,
                 group.line.width= labels_size/4)
-    p = p + theme(legend.title = element_blank()) 
+    p = p + theme(legend.title = element_blank())
     return(p)
   }
-  
+
   # 2.5. Function to run raster representation for factor variables ----------
   fun_raster_1 = function(data, vec_variable){
     variable = value = NULL  # to avoid no visible binding for global variable
-    
+
     vv = vm = vx = NULL
-    for(v in vec_variables) { 
+    for(v in vec_variables) {
       vv = c(vv, as.character(rep(v, nrow(data))))
       vm = c(vm, as.character(data[,v]))
       vx = c(vx, as.character(data$x_axis))
     }
-    
+
     dtmp = cbind.data.frame(
       variable = as.factor(vv),
       value = as.factor(vm),
       x_axis = as.factor(vx)
     )
-    
+
     p = ggplot(dtmp, aes(x = x_axis, y = variable))
     p = p + geom_raster(aes(fill = value))
     p = p + theme(axis.text.x=element_text(angle=90))
     return(p)
   }
-  
+
   fun_raster = function(d, vec_variables,
-                        x_axis, nb_parameters_per_plot_x_axis){ 
+                        x_axis, nb_parameters_per_plot_x_axis){
     vec_variable = NULL  # to avoid no visible binding for global variable
-    
+
     vv = vm = vx = NULL
-    for(v in vec_variables) { 
+    for(v in vec_variables) {
       vv = c(vv, as.character(rep(v, nrow(d))))
       vm = c(vm, as.character(d[,v]))
       vx = c(vx, as.character(d[,x_axis]))
     }
-    
+
     dtmp = cbind.data.frame(
       variable = as.factor(vv),
       value = as.factor(vm),
       x_axis = as.factor(vx)
     )
-    
+
     test = table(dtmp$x_axis)
-    if( sum(test) != length(test) ) { 
-      warning("There are no single value for each x_axis, therefore block, X and Y colums have been added in order to have single value.") 
+    if( sum(test) != length(test) ) {
+      warning("There are no single value for each x_axis, therefore block, X and Y colums have been added in order to have single value.")
       d$new_x_axis = paste(d[,x_axis], d$block, d$X, d$Y, sep = "-")
     } else { d$new_x_axis = d[,x_axis] }
     d = d[,-which(colnames(d) == x_axis)]
     x_axis = paste(x_axis, "block", "X", "Y", sep = "-")
     colnames(d)[which(colnames(d) == "new_x_axis")] = x_axis
-    
+
     d = reshape_data_split_x_axis_in_col(d, vec_variables, labels_on = NULL,
                                          x_axis, nb_parameters_per_plot_x_axis,
                                          in_col = NULL, nb_parameters_per_plot_in_col = NULL
@@ -1640,61 +1640,61 @@ plot_descriptive_data = function(
     out = lapply(d, fun_raster_1, vec_variable)
     return(out)
   }
-  
+
   # 2.6. Functions to run map ----------
   fun_pies_on_map = function(variable, p, data, pie_size){
     data_to_map = droplevels(unique(data[c("location", "long", "lat")]))
     p = add_pies(p, data_to_map, format = "data_agro", plot_type = "map", data, variable, pie_size)
-    return(p) 
+    return(p)
   }
-  
+
   fun_map = function(data, vec_variables, labels_on, labels_size, pie_size){
     data_to_map = droplevels(unique(data[c("location", "long", "lat")]))
-    p = pmap(data_to_map, format = NULL, labels_on, labels_size, zoom) 
+    p = pmap(data_to_map, format = NULL, labels_on, labels_size, zoom)
     if( !is.null(vec_variables) ){
       out = lapply(vec_variables, fun_pies_on_map, p, data, pie_size)
       names(out) = paste("pies_on_map", vec_variables, sep="_")
     } else { out = list(p); names(out) = "map" }
     return(out)
   }
-  
+
   # 2.7. Function to run data_version ----------
   fun_data_version_1 = function(variable, data, data_version, plot_type){
     id_azerty = group = NULL  # to avoid no visible binding for global variable
-    
+
     data_version_class = class(data_version)[2]
-    
+
     factor_to_split = "location" # default value
-    
+
     if( data_version_class == "data_agro_version_SR" ){
       data_version$lg = paste(data_version$location, data_version$germplasm, sep = ":")
       factor_to_split = "lg"
       data_version$group_bis = paste(data_version$germplasm, data_version$group, sep = "-")
     }
-    
+
     if( data_version_class == "data_agro_version_HA" ){
       data_version$group_bis =  paste("sown at", data_version$location, ", coming from", data_version$group)
       factor_to_split = "germplasm"
     }
-    
+
     if( data_version_class == "data_agro_version_LF" ){
       data_version$group_bis = paste("sown at", data_version$location, ", coming from", data_version$group)
       factor_to_split = "location"
     }
-    
+
     colnames(data)[which(colnames(data) == variable)] = "variable"
     data$id_azerty = paste(data$location, data$year, data$germplasm, sep = "-")
     data_version$id_azerty = paste(data_version$location, data_version$year, data_version$germplasm, sep = "-")
 
-    if( data_version_class == "data_agro_version_SR" ){ 
+    if( data_version_class == "data_agro_version_SR" ){
       # get row where id is present in both data set
       t1 = is.element(data_version$id_azerty, data$id_azerty)
       id_ok = data_version$id_azerty[t1]
       id_not_ok = data_version$id_azerty[!t1]
     }
-    
-    
-    if( data_version_class == "data_agro_version_HA" | data_version_class == "data_agro_version_LF" ){ 
+
+
+    if( data_version_class == "data_agro_version_HA" | data_version_class == "data_agro_version_LF" ){
       # get row where id is present in both data set
       t1 = is.element(data_version$id_azerty, data$id_azerty)
       # get rid of row where group (location of origin) is not present in the data set
@@ -1702,37 +1702,38 @@ plot_descriptive_data = function(
       id_ok = data_version[t1,]$id_azerty[t2]
       id_not_ok = data_version[t2,]$id_azerty[!t2]
     }
-      
-    
-    if( length(id_not_ok) > 0 ) { 
-      warning("The following rows are not taken into account in data_version: ", paste(id_not_ok, collape = ", ")) 
+
+
+    if( length(id_not_ok) > 0 ) {
+      warning("The following rows are not taken into account in data_version: ", paste(id_not_ok, collape = ", "))
       }
     if( length(id_not_ok) == length(t) ) { stop("There is not match between data_version and data. Not plot can be done.") }
     data_version = droplevels(dplyr::filter(data_version, id_azerty %in% id_ok))
     d = plyr::join(data_version, data, by = "id_azerty")
     d = droplevels(na.omit(d))
-    
-    if( data_version_class == "data_agro_version_HA" | data_version_class == "data_agro_version_LF" ){ 
+    d <- d[!duplicated(as.list(d))]
+
+    if( data_version_class == "data_agro_version_HA" | data_version_class == "data_agro_version_LF" ){
       # single plot with version for all germplasm/location merged
-      p = ggplot(d, aes(x = version, y = variable)) 
+      p = ggplot(d, aes(x = version, y = variable))
       p = p + theme(axis.text.x = element_text(angle = 90, hjust = 1)) + xlab("")
       if( plot_type == "barplot"){ p = p + geom_bar(stat = "identity", position = "dodge") }
       if( plot_type == "boxplot"){ p = p + geom_boxplot(position = "dodge") }
       p1 = p
-      
+
       # single plot with version for each germplasm/location
       if( data_version_class == "data_agro_version_HA" ){ p = ggplot(d, aes(x = germplasm, y = variable)) }
-      if( data_version_class == "data_agro_version_LF" ){ p = ggplot(d, aes(x = location, y = variable)) } 
+      if( data_version_class == "data_agro_version_LF" ){ p = ggplot(d, aes(x = location, y = variable)) }
       p = p + theme(axis.text.x = element_text(angle = 90, hjust = 1)) + xlab("")
       if( plot_type == "barplot"){
-        p = p + geom_bar(aes(fill = version), stat = "identity", position = "dodge")      
+        p = p + geom_bar(aes(fill = version), stat = "identity", position = "dodge")
       }
       if( plot_type == "boxplot"){
-        p = p + geom_boxplot(aes(fill = version), position = "dodge")      
+        p = p + geom_boxplot(aes(fill = version), position = "dodge")
       }
       p2 = p
       }
-    
+
     # plot for each germplasm/location with all version separated
     colnames(d)[which(colnames(d) == factor_to_split)] = "factor_to_split"
     dd = plyr:::splitter_d(d, .(factor_to_split))
@@ -1741,83 +1742,83 @@ plot_descriptive_data = function(
       p = p + ggtitle(x[1, "factor_to_split"]) + theme(axis.text.x = element_text(angle = 90, hjust = 1))
       p = p + xlab("")
       if( plot_type == "barplot"){
-        p = p + geom_bar(aes(fill = version), stat = "identity", position = "dodge")      
+        p = p + geom_bar(aes(fill = version), stat = "identity", position = "dodge")
       }
       if( plot_type == "boxplot"){
-        p = p + geom_boxplot(aes(fill = version), position = "dodge")      
+        p = p + geom_boxplot(aes(fill = version), position = "dodge")
       }
-      return(p)  
+      return(p)
     })
-    
-    if( data_version_class == "data_agro_version_SR" ){ 
+
+    if( data_version_class == "data_agro_version_SR" ){
       out = out
-    } 
-    
-    if( data_version_class == "data_agro_version_HA" ){ 
-      out = list("home_away_merged" = p1, 
-                 "home_away_merged_per_germplasm" = p2, 
+    }
+
+    if( data_version_class == "data_agro_version_HA" ){
+      out = list("home_away_merged" = p1,
+                 "home_away_merged_per_germplasm" = p2,
                  "home_away_per_germplasm" = out)
     }
-    
-    if( data_version_class == "data_agro_version_LF" ){ 
-      out = list("local_foreign_merged" = p1, 
-                 "local_foreign_merged_per_location" = p2, 
+
+    if( data_version_class == "data_agro_version_LF" ){
+      out = list("local_foreign_merged" = p1,
+                 "local_foreign_merged_per_location" = p2,
                  "local_foreign_per_location" = out)
-    } 
-    
-    
+    }
+
+
     return(out)
   }
-  
+
   fun_data_version = function(vec_variables, data, data_version, plot_type){
     out = lapply(vec_variables, fun_data_version_1, data, data_version, plot_type)
     names(out) = vec_variables
     return(out)
   }
-  
-  
+
+
   # 3. Run code ----------
   # 3.1. Presence absence for each germplasm, location and year
-  if(plot_type == "pam"){ 
-    p_out = fun_pam(data, vec_variables) 
+  if(plot_type == "pam"){
+    p_out = fun_pam(data, vec_variables)
   }
-  
+
   # 3.2. histogramm, barplot, boxplot, interaction ----------
-  if( is.element(plot_type, c("histogramm", "barplot", "boxplot", "interaction") )) { 
+  if( is.element(plot_type, c("histogramm", "barplot", "boxplot", "interaction") )) {
     p_out = fun_hbbi(data, vec_variables,
-                     x_axis, nb_parameters_per_plot_x_axis, 
-                     in_col, nb_parameters_per_plot_in_col, 
-                     plot_type)  
+                     x_axis, nb_parameters_per_plot_x_axis,
+                     in_col, nb_parameters_per_plot_in_col,
+                     plot_type)
   }
-  
+
   # 3.3. biplot ----------
   if(plot_type == "biplot") {
     p_out = fun_biplot(data, vec_variables, labels_on, labels_size,
-                       x_axis, nb_parameters_per_plot_x_axis, 
+                       x_axis, nb_parameters_per_plot_x_axis,
                        in_col, nb_parameters_per_plot_in_col)
   }
-  
+
   # 3.4. radar ----------
   if(plot_type == "radar") {
     p_out = fun_radar(data, vec_variables, in_col, labels_size)
   }
-  
+
   # 3.5. raster ----------
   if(plot_type == "raster") {
     p_out = fun_raster(data, vec_variables, x_axis, nb_parameters_per_plot_x_axis)
-  } 
-  
+  }
+
   # 3.6. map ------------
   if(plot_type == "map"){
     p_out = fun_map(data, vec_variables, labels_on, labels_size, pie_size)
-  }  
-  
+  }
+
   # 3.7. data_version ----------
   if( !is.null(data_version) ){
     p_out = fun_data_version(vec_variables, data, data_version, plot_type)
-  }  
-  
-  
+  }
+
+
   # 4. Return results ----------
   return(p_out)
 }
@@ -1829,7 +1830,7 @@ plot_descriptive_data = function(
 #' @return a data frame of class data_version_LF
 #' @importFrom methods is
 #' @export
-#' 
+#'
 HA_to_LF = function(data_version_HA){
   if(!is(data_version_HA, "data_agro_version_HA")){ stop(substitute(data_version_HA), " must be formated with type = \"data_agro_version\" with home away format, see PPBstats::format_data_PPBstats().") }
   is(data_version_HA)
@@ -1841,5 +1842,3 @@ HA_to_LF = function(data_version_HA){
   class(data_version_LF) = c("PPBstats", "data_agro_version_LF", "data.frame")
   return(data_version_LF)
 }
-
-

--- a/R/format_data_PPBstats.data_organo_napping.R
+++ b/R/format_data_PPBstats.data_organo_napping.R
@@ -2,23 +2,23 @@
 #'
 #' @description
 #' \code{format_data_PPBstats.data_organo_napping} checks and formats the data to be used by PPBstats functions for napping analyses
-#' 
+#'
 #' @param data The data frame with the following columns: sample, juges, X, Y, descriptors, germplasm, location.
 #' The descriptors must be separated by ";"
-#' 
+#'
 #' @param threshold number of occurence of descriptors <= threshold are kept
-#' 
+#'
 #' @details
 #' See the book for more details \href{https://priviere.github.io/PPBstats_book/napping.html#format-the-data-9}{here}.
-#' 
+#'
 #' @author Pierre Riviere
-#' 
+#'
 #' @seealso \code{\link{format_data_PPBstats}}
-#' 
+#'
 #' @export
-#' 
+#'
 format_data_PPBstats.data_organo_napping = function(data, threshold){
-  
+
   mess = "In data, the following column are compulsory : \"juges\", \"X\", \"Y\", \"descriptors\", \"germplasm\", \"location\"."
   if(!is.element("juges", colnames(data))) { stop(mess) }
   if(!is.element("X", colnames(data))) { stop(mess) }
@@ -26,18 +26,18 @@ format_data_PPBstats.data_organo_napping = function(data, threshold){
   if(!is.element("descriptors", colnames(data))) { stop(mess) }
   if(!is.element("germplasm", colnames(data))) { stop(mess) }
   if(!is.element("location", colnames(data))) { stop(mess) }
-  
+
   if( !is.factor(data$juges) ) { stop("juge must be a factor") }
   if( !is.numeric(data$X) ) { stop("X must be a numeric") }
   if( !is.numeric(data$Y) ) { stop("Y must be a numeric") }
   if( !is.factor(data$descriptors) ) { stop("descriptors must be a factor") }
   if( !is.factor(data$germplasm) ) { stop("germplasm must be a factor") }
   if( !is.factor(data$location) ) { stop("location must be a factor") }
-  
+
   N = format_organo(data, threshold)
   N = N[,c(6, 1, 2, 3, c(7:ncol(N)))]
   descriptors = colnames(N)[c(7:ncol(N))]
-  
+
   # Get table with, for each judge, the X and Y for each sample tasted ----------
   juges = levels(N$juges)
   f = nlevels(N$sample)
@@ -45,7 +45,7 @@ format_data_PPBstats.data_organo_napping = function(data, threshold){
   colnames(d_juges) = "sample"
   nb = c(1:length(juges)); names(nb) = juges
   juges_to_delete = NULL
-  
+
   for (i in juges){
     dtmp = droplevels(subset(N, juges == i))
     sample = dtmp$sample
@@ -56,45 +56,46 @@ format_data_PPBstats.data_organo_napping = function(data, threshold){
       Xi = dtmp$X
       Yi = dtmp$Y
       d_juges_tmp = cbind.data.frame(sample, Xi, Yi)
-      colnames(d_juges_tmp) = c("sample", 
-                                paste("X", nb[i], "-juge-", i, sep = ""), 
+      colnames(d_juges_tmp) = c("sample",
+                                paste("X", nb[i], "-juge-", i, sep = ""),
                                 paste("Y", nb[i], "-juge-", i, sep = "")
       )
       d_juges = plyr::join(d_juges, d_juges_tmp, by = "sample")
+      d_juges <- d_juges[!duplicated(as.list(d_juges))]
     }
   }
-  
+
   # 3.1. update juges for MFA after
   if( !is.null(juges_to_delete) ) { juges = juges[!is.element(juges, juges_to_delete)] }
-  
+
   # 3.2. Add to d_juges the number of time the adjective was cited
   adj = colnames(N)[5:ncol(N)]
   b = as.data.frame(matrix(0, ncol = length(adj), nrow = nrow(d_juges)))
   colnames(b) = adj
-  
+
   d_juges = cbind.data.frame(d_juges, b)
-  
+
   sample = as.character(d_juges$sample)
-  
+
   for (ech in sample){
     dtmp = droplevels(subset(N, sample == ech))
     for (ad in adj){
       d_juges[which(d_juges$sample == ech), ad] = sum(dtmp[,ad])
     }
   }
-  
+
   select <- is.na (d_juges) # on vire les NA: pourquoi? Pourquoi ne pas mettre 0 ou la moyenne ?
   aeliminer <- apply(select, MARGIN = 1, FUN = any)
   d_MFA <- d_juges[!aeliminer, ]
   row.names(d_MFA) <- d_MFA[, 1]
   d = d_MFA[,2:ncol(d_MFA)]
-  
+
   d$sample = factor(rownames(d))
-  
-  d = list("data" = d, 
+
+  d = list("data" = d,
            "descriptors" = descriptors
            )
-  
+
   class(d) <- c("PPBstats", "data_organo_napping")
   message(substitute(data), " has been formated for PPBstats functions.")
   return(d)

--- a/R/ggplot_discrimitiveness_vs_representativeness.R
+++ b/R/ggplot_discrimitiveness_vs_representativeness.R
@@ -1,8 +1,8 @@
 #' Return a "discrimitiveness vs representativeness" ggplot based on PCA object
-#' 
+#'
 #' @description
 #' \code{ggplot_discrimitiveness_vs_representativeness} returns a "discrimitiveness vs representativeness" ggplot based on PCA object
-#' 
+#'
 #' @param res.pca output from \code{\link{biplot_data.check_model_GxE}}
 #'
 #' @details
@@ -11,50 +11,50 @@
 #' A red circle indicates the position of the average location, which is defined by the average Dim1 and Dim2 scores across all locations.
 #' An arrow points this average 'virtual' location.
 #' A red line passes through the biplot origin and the average location (known as the Average-Tester Axis (ATA)).
-#' 
+#'
 #' \itemize{
 #'  \item discrimitiveness : assess discrimitiveness of each location.
 #'  The score represents the discrimination : the higher the vector, the more discriminating the location.
-#'      
+#'
 #'  \item representativeness : assess representativeness of each location.
 #'  The score represents the representativeness : the higher the score, the less representative the location.
-#'      
+#'
 #'  \item discrimitiveness_vs_representativeness :  represent discrimitiveness versus representativeness.
 #'  The location combining better score (i. e.discrimination and representativeness) are the ones that could be used to test germplasms as they are more representative of all the locations.
 #'  This has to be done severals year to get robust results.
 #'  The highest the score, the more disciminative and representative the location.
 #'  }
-#'   
-#' @return 
+#'
+#' @return
 #' A ggplot object.
-#' 
+#'
 #' @author Pierre Riviere
-#' 
+#'
 #' @seealso
 #' \code{\link{plot.PPBstats}}
 #' \code{\link{plot.biplot_GxE}}
-#' 
+#'
 #' @import ggplot2
 #' @import dplyr
-#' 
+#'
 #' @export
-#' 
+#'
 ggplot_discrimitiveness_vs_representativeness = function(res.pca){
   color = score = score_discrimitiveness = score_representativeness = label = NULL  # to avoid no visible binding for global variable
-  
+
   p = get_biplot(res.pca)
-  
+
   var = dplyr::filter(p$data, color == "darkgreen")
   xymean = data.frame(x1 = 0, y1 = 0, x2 = mean(var$x), y2 = mean(var$y))
   p = p + geom_point(data = xymean, aes(x = x2, y = y2), shape = 21, size = 5, color = "red", fill = "white", stroke = 2, alpha = 0.7, inherit.aes = FALSE) # add mean location
   p = p + geom_segment(data = xymean, aes(x = x1, y = y1, xend = x2, yend = y2), arrow=arrow(length=unit(0.4,"cm")), color = "red", inherit.aes = FALSE)
   p = p + geom_abline(intercept = 0, slope = xymean$y2 / xymean$x2, color = "red") # add line that passes through the biplot origin and the average location
-  
+
   p_common = p
-  
+
   # discrimitiveness ----------
   d = data.frame(x1 = 0, y1 = 0, x2 = var$x, y2 = var$y)
-  
+
   # distance of each location from the plot origin
   d$score = NA
   for(i in 1:nrow(d)){
@@ -66,15 +66,16 @@ ggplot_discrimitiveness_vs_representativeness = function(res.pca){
     py = y2-y1
     d[i,"score"] = round(px*px + py*py, 2)
   }
-  
+
   colnames(var)[2:3] = c("x2", "y2")
   a_disc = plyr::join(var, d, by = "x2")[c("label", "x1", "y1", "x2", "y2", "score")]
+  a_disc <- a_disc[!duplicated(as.list(a_disc))]
   vec_disc = as.character(paste("Ranking of locations: \n", paste(a_disc$label, collapse = " > "), sep = ""))
-  
+
   p = p_common + geom_segment(data = d, aes(x = x1, y = y1, xend = x2, yend = y2, color = score), linetype = 2, size = 1, inherit.aes = FALSE)
   p = p + scale_colour_gradient(low = "green", high = "red")
   p_discri = p + ggtitle("Discrimitiveness", vec_disc)
-  
+
   # representativeness ----------
   per_line = data.frame()
   for(i in 1:nrow(var)) {
@@ -84,40 +85,41 @@ ggplot_discrimitiveness_vs_representativeness = function(res.pca){
     y2 = xymean$y2
     x3 = var$x[i]
     y3 = var$y[i]
-    
+
     obj = get_perpendicular_segment(x1, y1, x2, y2, x3, y3)
-    
+
     per_line = rbind.data.frame(per_line, obj)
   }
   colnames(per_line) = c("x1", "y1", "x2", "y2")
   per_line$score = round((per_line$x1 - per_line$x2)^2 + (per_line$y1 - per_line$y2)^2, 2)
-  
+
   colnames(var)[2:3] = c("x1", "y1")
   a_repr = plyr::join(var, per_line, by = "x1")[c("label", "x1", "y1", "x2", "y2", "score")]
+  a_repr <- a_repr[!duplicated(as.list(a_repr))]
   vec_rank = as.character(paste("Ranking of locations: \n", paste(a_repr$label, collapse = " > "), sep = ""))
-  
+
   p = p_common + geom_segment(aes(x = x1, y = y1, xend = x2, yend = y2, color = score), data = per_line, linetype = 2, size = 1, inherit.aes = FALSE)
   p = p + scale_colour_gradient(low = "green", high = "red")
   p_repre = p + ggtitle("Representativeness", vec_rank)
 
-  
+
   # discrimitiveness vs representativeness
   a_disc = a_disc[,c("label", "score")]
   colnames(a_disc)[2] = "score_discrimitiveness"
   a_repr = a_repr[,c("label", "score")]
   colnames(a_repr)[2] = "score_representativeness"
   d = plyr::join(a_disc, a_repr, by = "label")
+  d <- d[!duplicated(as.list(d))]
   d$score = d$score_discrimitiveness * d$score_representativeness
-  p_disc_vs_repr = ggplot(d, aes(x = score_discrimitiveness, y = score_representativeness, label = label, color = score)) + geom_text() 
+  p_disc_vs_repr = ggplot(d, aes(x = score_discrimitiveness, y = score_representativeness, label = label, color = score)) + geom_text()
   p_disc_vs_repr = p_disc_vs_repr + scale_colour_gradient(low = "green", high = "red")
-  
+
   # return results ----------
   p = list(
-    "discrimitiveness" = p_discri, 
+    "discrimitiveness" = p_discri,
     "representativeness" = p_repre,
     "discrimitiveness_vs_representativeness" = p_disc_vs_repr
     )
 
   return(p)
 }
-

--- a/R/ggplot_mean_vs_stability.R
+++ b/R/ggplot_mean_vs_stability.R
@@ -1,8 +1,8 @@
 #' Return a "mean vs stability" ggplot based on PCA object
-#' 
+#'
 #' @description
 #' \code{ggplot_mean_vs_stability} returns a "mean vs stability" ggplot based on PCA object
-#' 
+#'
 #' @param res.pca output from \code{\link{biplot_data.check_model_GxE}}
 #'
 #' @details
@@ -12,49 +12,49 @@
 #' A red line passes through the biplot origin and the average location (known as the Average-Tester Axis (ATA)).
 #' A red line is set perpendicular the ATA.
 #' Dashed perpendicular lines to the ATA are drawn and passed through each germplasm.
-#' 
+#'
 #' \itemize{
-#'  \item mean_performance : assess mean performance score of each germplasm. 
+#'  \item mean_performance : assess mean performance score of each germplasm.
 #'  The mean performance score is the rank of germplasm along the ATA.
 #'  The arrow points the greatest value according to their mean performance across all locations.
 #'  An high score, represents an high mean performance.
 #'  A low score reresents an low mean performance.
 #'  Score are displayed into the legend.
-#'      
+#'
 #'  \item stability_performance : assess stability performance score of each germplasm.
 #'  The stability performance score of the germplasms are represented by the projection from the germplasm to the ATA.
 #'  An high score, represents an high interaction and therfore lower stability.
 #'  A low score reresents an low interaction and therefore an high stability.
 #'  Score are displayed into the legend.
 #'  }
-#'  
-#' @return 
+#'
+#' @return
 #' A ggplot object.
-#' 
+#'
 #' @author Pierre Riviere
-#' 
+#'
 #' @seealso
 #' \code{\link{plot.PPBstats}}
 #' \code{\link{plot.biplot_GxE}}
-#' 
+#'
 #' @import ggplot2
 #' @import dplyr
-#' 
+#'
 #' @export
-#' 
+#'
 ggplot_mean_vs_stability = function(res.pca){
   color = mean_score = stability_score = NULL # to avoid no visible binding for global variable
-  
+
   p = get_biplot(res.pca)
-  
+
   var = dplyr::filter(p$data, color == "darkgreen")
   xymean = data.frame(x1 = 0, y1 = 0, x2 = mean(var$x), y2 = mean(var$y))
   p = p + geom_point(data = xymean, aes(x = x2, y = y2), shape = 21, size = 5, color = "red", fill = "white", stroke = 2, alpha = 0.7, inherit.aes = FALSE) # add mean location
   p = p + geom_segment(data = xymean, aes(x = x1, y = y1, xend = x2, yend = y2), arrow=arrow(length=unit(0.4,"cm")), color = "red", inherit.aes = FALSE)
-  
+
   p = p + geom_abline(intercept = 0, slope = xymean$y2 / xymean$x2, color = "red") # add line that passes through the biplot origin and the average location
   p = p + geom_abline(intercept = 0, slope = - 1 / (xymean$y2 / xymean$x2), color = "red") # add line that is perpendicular to previous line and passes through 0
-  
+
   ind = dplyr::filter(p$data, color == "black")
   per_line = data.frame()
   for(i in 1:nrow(ind)) {
@@ -64,21 +64,21 @@ ggplot_mean_vs_stability = function(res.pca){
     y2 = xymean$y2
     x3 = ind$x[i]
     y3 = ind$y[i]
-    
+
     obj = get_perpendicular_segment(x1, y1, x2, y2, x3, y3)
 
     per_line = rbind.data.frame(per_line, obj)
   }
   colnames(per_line) = c("x1", "y1", "x2", "y2")
-  
+
   p_common = p
-  
+
   # Graph for means performance
   per_line$mean_score = round(sqrt(per_line$x2*per_line$x2 + per_line$y2*per_line$y2), 2)
-  
+
   # the arrow point the greatest value (i.e. greater score)
   slope = -1 / (xymean$y2 / xymean$x2)
-  
+
   for(i in 1:nrow(per_line)) {
     x = per_line[i, "x1"]
     y = per_line[i, "y1"]
@@ -94,30 +94,32 @@ ggplot_mean_vs_stability = function(res.pca){
       per_line[i, "mean_score"] = per_line[i, "mean_score"] * -1
     }
   }
-  
+
   colnames(ind)[2:3] = c("x1", "y1")
   a = plyr::join(ind, per_line, by = "x1")[c("label", "mean_score")]
-  a = dplyr::arrange(a, -mean_score) 
-  
+  a = dplyr::arrange(a, -mean_score)
+  a <- a[!duplicated(as.list(a))]
+
   vec_rank = as.character(paste("Ranking of entries: \n", paste(a$label, collapse = " > "), sep = ""))
-  
+
   p = p_common + geom_segment(aes(x = x1, y = y1, xend = x2, yend = y2, color = mean_score), data = per_line, linetype = 2, size = 1, inherit.aes = FALSE)
   p = p + scale_colour_gradient(low = "green", high = "red")
   p_mean = p + ggtitle("Mean performance", vec_rank)
-  
+
   # Graph for stability performance
   per_line$stability_score = round((per_line$x1 - per_line$x2)^2 + (per_line$y1 - per_line$y2)^2, 2)
 
   colnames(ind)[2:3] = c("x1", "y1")
   a = plyr::join(ind, per_line, by = "x1")[c("label", "stability_score")]
   a = dplyr::arrange(a, -stability_score)
-  
+  a <- a[!duplicated(as.list(a))]
+
   vec_rank = as.character(paste("Ranking of entries: \n", paste(a$label, collapse = " > "), sep = ""))
-  
+
   p = p_common + geom_segment(aes(x = x1, y = y1, xend = x2, yend = y2, color = stability_score), data = per_line, linetype = 2, size = 1, inherit.aes = FALSE)
   p = p + scale_colour_gradient(low = "green", high = "red")
   p_stability = p + ggtitle("Stability performance", vec_rank)
-  
+
   p = list("mean_performance" = p_mean, "stability_performance" = p_stability)
   return(p)
 }

--- a/R/model_home_away.R
+++ b/R/model_home_away.R
@@ -2,15 +2,15 @@
 #'
 #' @description
 #' \code{model_home_away} runs home away model
-#' 
-#' @param data The data frame on which the model is run. 
+#'
+#' @param data The data frame on which the model is run.
 #' It should come from \code{\link{format_data_PPBstats.data_agro}}
-#' 
+#'
 #' @param data_version It should come from \code{\link{format_data_PPBstats.data_agro_version}} with home and away in version
-#' 
+#'
 #' @param variable variable to analyse
-#' 
-#' @return 
+#'
+#' @return
 #' The function returns a list with three elements :
 #' \itemize{
 #'  \item info : a list with variable
@@ -20,65 +20,66 @@
 #'    \item anova_model
 #'   }
 #' }
-#' 
-#' @details 
+#'
+#' @details
 #' Find details in the book \href{https://priviere.github.io/PPBstats_book/family-4.html#family-4}{here}.
-#' @author 
+#' @author
 #' Pierre Riviere and Gaelle Van Frank
-#' 
-#' @seealso 
+#'
+#' @seealso
 #' \itemize{
 #' \item \code{\link{check_model}}
 #' \item \code{\link{check_model.fit_model_home_away}}
 #' }
-#' 
+#'
 #' @export
-#' 
-#' @import plyr 
+#'
+#' @import plyr
 #' @import dplyr
 #' @import stats
-#' 
+#'
 model_home_away = function(data, data_version, variable){
   # 1. Error messages ----------
   if(!is(data, "data_agro")){ stop(substitute(data), " must be formated with type = \"data_agro\", see PPBstats::format_data_PPBstats().") }
   if(!is(data_version, "data_agro_version_HA")){ stop(substitute(data_version), " must be formated with type = \"data_agro_version\" and home away in version, see PPBstats::format_data_PPBstats.data_agro_version") }
   check_data_vec_variables(data, variable)
-  
+
   # 2. Set up data set ----------
   colnames(data)[which(colnames(data) == variable)] = "variable"
   data$id_azerty = paste(data$location, data$year, data$germplasm, sep = "-")
   data_version$id_azerty = paste(data_version$location, data_version$year, data_version$germplasm, sep = "-")
-  
+
   # get row where id is present in both data set
   t1 = is.element(data_version$id_azerty, data$id_azerty)
   # get rid of row where group (location of origin) is not present in the data set
   t2 = is.element(data_version[t1,]$group, data_version[t1,]$location)
   id_ok = data_version[t1,]$id_azerty[t2]
   id_not_ok = data_version[t2,]$id_azerty[!t2]
-  
-  if( length(id_not_ok) > 0 ) { 
-    warning("The following rows are not taken into account in data_version: ", paste(id_not_ok, collape = ", ")) 
+
+  if( length(id_not_ok) > 0 ) {
+    warning("The following rows are not taken into account in data_version: ", paste(id_not_ok, collape = ", "))
   }
   if( length(id_not_ok) == length(t) ) { stop("There is not match between data_version and data. Not analysis can be done.") }
   data_version = droplevels(dplyr::filter(data_version, id_azerty %in% id_ok))
-  
+
   data = plyr::join(data_version, data, by = "id_azerty")
   data = data[c("location", "germplasm", "year", "block", "version", "variable")]
   data = droplevels(na.omit(data))
-  
+  data <- data[!duplicated(as.list(data))]
+
   # 3. ANOVA ----------
-  
+
   if(nlevels(data$year) > 1) { # depends on the years available in the data set
-    model <- stats::lm(variable ~ location + germplasm + year + version + location:year/block + year:location + 
-                  version:germplasm + version:germplasm:year, 
+    model <- stats::lm(variable ~ location + germplasm + year + version + location:year/block + year:location +
+                  version:germplasm + version:germplasm:year,
                 data = data)
   } else {
-    model <- stats::lm(variable ~ location + germplasm + version + location/block + 
+    model <- stats::lm(variable ~ location + germplasm + version + location/block +
                          version:germplasm, data = data)
   }
-  
+
   anova_model = stats::anova(model)
-  
+
   # 5. Return results ----------
   out = list(
     "info" = list("variable" = variable),
@@ -87,7 +88,7 @@ model_home_away = function(data, data_version, variable){
       "anova_model" = anova_model
     )
   )
-  
+
   class(out) <- c("PPBstats", "fit_model_home_away")
-  return(out)  
+  return(out)
 }

--- a/R/plot.mean_comparisons_model_bh_GxE.R
+++ b/R/plot.mean_comparisons_model_bh_GxE.R
@@ -4,43 +4,43 @@
 #' \code{plot.mean_comparisons_model_bh_GxE} returns ggplot to visualize outputs from \code{\link{mean_comparisons.check_model_bh_GxE}}
 #'
 #' @param x Output from \code{\link{mean_comparisons.check_model_bh_GxE}} for a given parameter
-#' 
+#'
 #' @param y Output from \code{\link{mean_comparisons.check_model_bh_GxE}} for a given parameter
-#' 
+#'
 #' @param plot_type "biplot-alpha-beta" or "barplot"
-#' 
+#'
 #' @param nb_parameters_per_plot number of parameter per plot to display
-#' 
+#'
 #' @param ... further arguments passed to or from other methods
 #'
 #' @details
 #' S3 method.
 #' y can not be NULL for plot_type = "biplot-alpha-beta".
 #' See example in the book: https://priviere.github.io/PPBstats_book/family-2.html#model-2
-#' 
-#' @return 
+#'
+#' @return
 #' A list with ggplot object depending on plot_type.
 #' There are as many graph as needed with \code{nb_parameters_per_plot} parameters per graph.
 #' \itemize{
-#'  \item barplot : 
-#'  Letters are displayed on each bar. 
-#'  Parameters that do not share the same letters are different regarding type I error (alpha) and alpha correction. 
-#'  The error I (alpha) and the alpha correction are displayed in the title. 
+#'  \item barplot :
+#'  Letters are displayed on each bar.
+#'  Parameters that do not share the same letters are different regarding type I error (alpha) and alpha correction.
+#'  The error I (alpha) and the alpha correction are displayed in the title.
 #'  alpha = Imp means that no differences were possible to find.
-#'  \item biplot-alpha-beta : display the biplot with alpha_i on the x axis and beta_i on the y axis if 
+#'  \item biplot-alpha-beta : display the biplot with alpha_i on the x axis and beta_i on the y axis if
 #'  x and y are coming respectively from \code{\link{mean_comparisons.check_model_bh_GxE}} for alpha and beta.
 #'  }
-#' 
+#'
 #' @author Pierre Riviere
-#' 
+#'
 #' @seealso \code{\link{mean_comparisons.check_model_bh_GxE}}
-#' 
+#'
 #' @export
-#'    
+#'
 #' @import dplyr
 #' @import plyr
 #' @import ggplot2
-#'    
+#'
 plot.mean_comparisons_model_bh_GxE <- function(
   x,
   y = NULL,
@@ -48,29 +48,29 @@ plot.mean_comparisons_model_bh_GxE <- function(
   nb_parameters_per_plot = 8, ...
 ) {
   parameter = alpha_i = beta_i = germplasm = NULL # to avoid no visible binding for global variable
-  
+
   # 1. Error message
   plot_type <- match.arg(plot_type, several.ok = FALSE)
-  
+
   if( is.null(y) & plot_type == "biplot-alpha-beta" ) {
     stop("With plot_type = \"biplot-alpha-beta\", y can not be NULL.")
   }
-  
+
   if (!is.null(y) && !inherits(y, "mean_comparisons_model_bh_GxE")) {
     stop(substitute(y), "must come from PPBstats::check_model from model_bh_GxE.")
   }
-  
+
   data_Mpvalue = x$Mpvalue
   data = x$mean.comparisons
-  
-  if(plot_type == "barplot") {  
-    data = dplyr::arrange(data, median)  
+
+  if(plot_type == "barplot") {
+    data = dplyr::arrange(data, median)
     data$max = max(data$median, na.rm = TRUE)
     data$split = add_split_col(data, nb_parameters_per_plot)
-    data_split = plyr:::splitter_d(data, .(split))  
-    
+    data_split = plyr:::splitter_d(data, .(split))
+
     para.name = unlist(strsplit(as.character(data[1, "parameter"]), "\\["))[1]
-    
+
     out = lapply(data_split, function(dx){
       p = ggplot(dx, aes(x = reorder(parameter, median), y = median)) + geom_bar(stat = "identity")
       p = p + geom_text(aes(x = reorder(parameter, median), y = median/2, label = groups), angle = 90, color = "white")
@@ -81,45 +81,45 @@ plot.mean_comparisons_model_bh_GxE <- function(
     out = list(out)
     names(out) = para.name
   }
-  
-  
+
+
   # 2.5. biplot-alpha-beta ----------
   if(plot_type == "biplot-alpha-beta"){
-    
+
     a = data
     test_a = unlist(strsplit(as.character(a[1,"parameter"]), "\\["))[1]
     if( test_a != "alpha" ){ stop("With plot_type = \"biplot-alpha-beta\", data must come from get.mean.comparisons with paramater = \"alpha\".") }
     a$germplasm = gsub("alpha", "", a$parameter)
     colnames(a)[which(colnames(a) == "parameter")] = "parameter_a"
     colnames(a)[which(colnames(a) == "median")] = "alpha_i"
-    
+
     b = y$mean.comparisons
     test_b = unlist(strsplit(as.character(b[1,"parameter"]), "\\["))[1]
     if( test_b != "beta" ){ stop("With plot_type = \"biplot-alpha-beta\", data_2 must come from get.mean.comparisons with paramater = \"beta\".") }
     b$germplasm = gsub("beta", "", b$parameter)
     colnames(b)[which(colnames(b) == "parameter")] = "parameter_b"
     colnames(b)[which(colnames(b) == "median")] = "beta_i"
-    
-    
+
+
     ab = plyr::join(a, b, "germplasm")
+    ab <- ab[!duplicated(as.list(ab))]
     ab=ab[which(!is.na(ab$beta_i) & !is.na(ab$alpha_i)),]
     ab$germplasm = gsub("\\[", "", ab$germplasm)
     ab$germplasm = gsub("\\]", "", ab$germplasm)
-    
+
     spl = add_split_col(ab, nb_parameters_per_plot)
     ab$split  = sample(spl,size = length(spl), replace=F)
     d_ab = plyr:::splitter_d(ab, .(split))
-    
+
     xlim = range(ab$alpha_i)
     ylim = range(ab$beta_i)
-    
+
     out = lapply(d_ab,function(y){
       p = ggplot(y, aes(x = alpha_i, y = beta_i, label = germplasm)) + coord_cartesian(xlim = xlim, ylim = ylim, expand = FALSE)
       p = p + geom_text() + geom_hline(yintercept = 0)
     })
   }
-  
+
   # return results
   return(out)
 }
-

--- a/R/plot.mean_comparisons_model_bh_intra_location.R
+++ b/R/plot.mean_comparisons_model_bh_intra_location.R
@@ -3,40 +3,40 @@
 #' @description
 #' \code{plot.mean_comparisons_model_bh_intra_location} returns ggplot to visualize outputs from \code{\link{mean_comparisons.check_model_bh_intra_location}}
 #'
-#' @param x Output from \code{\link{mean_comparisons.check_model_bh_intra_location}} 
-#' 
-#' @param data_version Output from \code{\link{format_data_PPBstats.data_agro_version}} 
-#' 
+#' @param x Output from \code{\link{mean_comparisons.check_model_bh_intra_location}}
+#'
+#' @param data_version Output from \code{\link{format_data_PPBstats.data_agro_version}}
+#'
 #' @param plot_type "interaction", "barplot" or "score"
-#' 
+#'
 #' @param nb_parameters_per_plot number of parameter per plot to display
-#' 
+#'
 #' @param ... further arguments passed to or from other methods
 #'
 #' @details
 #' S3 method.
 #' See example in the book: https://priviere.github.io/PPBstats_book/family-2.html#model-1
 #' For an example with data_version : https://priviere.github.io/PPBstats_book/family-4.html#version
-#' 
-#' @return 
+#'
+#' @return
 #' A list with ggplot object depending on plot_type.
-#' For each plot_type, it is a list of three elements being lists with as many elements as environment. 
+#' For each plot_type, it is a list of three elements being lists with as many elements as environment.
 #' For each element of the list, there are as many graph as needed with \code{nb_parameters_per_plot} parameters per graph.
 #' \itemize{
-#' \item barplot : 
+#' \item barplot :
 #'  \itemize{
 #'   \item data_mean_comparisons : only environments where all MCMC converge are represented.
-#'   Letters are displayed on each bar. Parameters that do not share the same letters are different regarding type I error (alpha) and alpha correction. 
-#'   The error I (alpha) and the alpha correction are displayed in the title. 
+#'   Letters are displayed on each bar. Parameters that do not share the same letters are different regarding type I error (alpha) and alpha correction.
+#'   The error I (alpha) and the alpha correction are displayed in the title.
 #'   alpha = Imp means that no differences were possible to find.
-#'        
+#'
 #'   \item data_env_with_no_controls : only environments where there were no controls are represented.
 #'   \item data_env_whose_param_did_not_converge : only environments where MCMC did not converge are represented.
 #'   }
 #'  Note that when using data_version, the pvalue is computed based on the MCMC.
 #'  For data that did not converge or without environments, it is a \code{t.test} which is perform.
-#'       
-#'  \item interaction : 
+#'
+#'  \item interaction :
 #'  \itemize{
 #'   \item data_mean_comparisons : only environments where all MCMC converge are represented.
 #'   The error I (alpha) and the alpha correction are displayed in the x.axis under the form "alpha | alpha correction".
@@ -44,7 +44,7 @@
 #'   \item data_env_with_no_controls : only environments where there were no controls are represented.
 #'   \item data_env_whose_param_did_not_converge : only environments where MCMC did not converge are represented.
 #'   }
-#'  
+#'
 #'  \item score : The score is set according to which group the entry was allocated.
 #'  An high score means that the entry was in a group with an high mean.
 #'  A low score means that the entry was in a group with an low mean.
@@ -52,52 +52,52 @@
 #'  The error I (alpha) and the alpha correction are displayed in the x.axis under the form "alpha | alpha correction".
 #'  alpha = Imp means that no differences were possible to find.
 #'  }
-#'    
+#'
 #' @author Pierre Riviere
-#' 
+#'
 #' @seealso \code{\link{mean_comparisons.check_model_bh_intra_location}}
-#' 
+#'
 #' @export
-#' 
+#'
 #' @import dplyr
 #' @import plyr
 #' @import ggplot2
 #' @importFrom methods is
-#' 
+#'
 plot.mean_comparisons_model_bh_intra_location <- function(
   x,
   data_version = NULL,
   plot_type = c("interaction", "barplot", "score"),
   nb_parameters_per_plot = 8, ...
   ){
-  
+
   # 1. Error message ----------
   plot_type <- match.arg(plot_type, several.ok = FALSE)
   if( !is.null(data_version)){
-    if(!is(data_version, "data_agro_version")){ 
-      stop(substitute(data_version), " must be formated with type = \"data_agro_version\", see PPBstats::format_data_PPBstats().") 
+    if(!is(data_version, "data_agro_version")){
+      stop(substitute(data_version), " must be formated with type = \"data_agro_version\", see PPBstats::format_data_PPBstats().")
     }
   }
-  
+
   # 2. get data ----------
   all_data = list(
     "data_mean_comparisons" = x$data_mean_comparisons,
     "data_env_with_no_controls" = x$data_env_with_no_controls,
     "data_env_whose_param_did_not_converge" = x$data_env_whose_param_did_not_converge
   )
-  
+
   # 3. get ggplot ----------
-  
+
   # 3.1. function used in the code ----------
   add_stars_version = function(dx, data, data_version){
     group = NULL # to avoid no visible binding for global variable
-    
+
     # Add letters of significant groups
     env = dx$environment[1]
     if( !is.null(data) ){ data_Mpvalue_env = data[[env]]$Mpvalue } else { data_Mpvalue_env = NULL }
     data_version_tmp = droplevels(dplyr::filter(data_version, environment == env))
     gp = unique(data_version_tmp$group)
-    
+
     STARS = NULL
     for(g in gp){
       dtmp = droplevels(dplyr::filter(data_version_tmp, group == g))
@@ -105,9 +105,9 @@ plot.mean_comparisons_model_bh_intra_location <- function(
       v1 = unique(as.character(dplyr::filter(dtmp, version == vec_version[1])$parameter))
       v2 = unique(as.character(dplyr::filter(dtmp, version == vec_version[2])$parameter))
       if(length(v1)>0 & length(v2)>0){
-        if( !is.null(data_Mpvalue_env) ){ 
-          
-          for (i in 1:ncol(data_Mpvalue_env)) { 
+        if( !is.null(data_Mpvalue_env) ){
+
+          for (i in 1:ncol(data_Mpvalue_env)) {
             if (colnames(data_Mpvalue_env)[i] == v1) {c1 = i}
             if (colnames(data_Mpvalue_env)[i] == v2) {c2 = i}
           }
@@ -115,12 +115,12 @@ plot.mean_comparisons_model_bh_intra_location <- function(
         } else {
           if( length(v1) > 1 & length(v2) > 1) {
             pvalue = t.test(v1, v2)$p.value
-          } else { 
+          } else {
             pvalue = NULL
-            warning(attributes(data)$PPBstats.object, ": no t.test are done as there are not enough observations.") 
+            warning(attributes(data)$PPBstats.object, ": no t.test are done as there are not enough observations.")
           }
         }
-        
+
         if(is.null(pvalue)) { stars = " "} else {
           if(pvalue < 0.001) { stars = "***" }
           if(pvalue > 0.001 & pvalue < 0.05) { stars = "**" }
@@ -131,23 +131,24 @@ plot.mean_comparisons_model_bh_intra_location <- function(
         STARS = c(STARS, stars)
       }
     }
-    
+
  #   colnames(dx)[which(colnames(dx) == "parameter")] = "mu"
     d = plyr::join(data_version_tmp, dx, by = "parameter")
-    
+    d <- d[!duplicated(as.list(d))]
+
     # delete version where there are not v1 AND v2
     group_to_keep = NULL
     vec_group = unique(d$group)
-    
+
     for(gp in vec_group){
       d_tmp = droplevels(d[d$group %in% gp,])
       t = tapply(d_tmp$median, d_tmp$version, mean, na.rm = TRUE)
-      if(!is.na(t[1]) & !is.na(t[2])){ group_to_keep = c(group_to_keep, gp)} 
+      if(!is.na(t[1]) & !is.na(t[2])){ group_to_keep = c(group_to_keep, gp)}
     }
-    
+
     d = droplevels(d[d$group %in% group_to_keep,])
     STARS = STARS[is.element(names(STARS), group_to_keep)]
-    
+
     p = ggplot(d, aes(x = group, y = median)) + geom_bar(aes(fill = version), stat = "identity", position = "dodge")
     y = tapply(d$median, d$group, mean, na.rm = TRUE)
     y = y + (max(y) * 0.2)
@@ -156,18 +157,18 @@ plot.mean_comparisons_model_bh_intra_location <- function(
     p = p + xlab("") + theme(axis.text.x = element_text(angle = 90)) + coord_cartesian(ylim = c(0, dx[1,"max"]))
     return(p)
   }
-  
-  
+
+
   get.loc.year = function(data, nb_parameters_per_plot){
     s = median_year = NULL # to avoid no visible binding for global variable
-    
+
     if( length(data) > 0 ) {
       dtmp = data.frame()
       for(i in 1:length(data)){ dtmp = rbind.data.frame(dtmp, data[[i]]$mean.comparisons) }
       data = dtmp
-      
+
       d_loc = plyr:::splitter_d(data, .(location))
-      
+
       d_loc_b = lapply(d_loc, function(x){
 
         data_year = max(as.numeric(as.character(x$year)))
@@ -178,7 +179,7 @@ plot.mean_comparisons_model_bh_intra_location <- function(
         t$median_year = unlist(lapply(rownames(t),function(y){
           ifelse(nrow(x[x$year %in% data_year & x$entry %in% y,])>0,x[x$year %in% data_year & x$entry %in% y,"median"],NA)
         }))
-        
+
         vec = NULL
         for(i in (ncol(t)-2):1){
           tmp = t[which(t[,i] > 0),]
@@ -191,63 +192,63 @@ plot.mean_comparisons_model_bh_intra_location <- function(
         ee = c(1:length(vec)); names(ee) = vec
         x$split = ee[x$entry]
         x = dplyr::arrange(x, split)
-        
+
         seq_nb_para = unique(c(seq(1, max(x$split), nb_parameters_per_plot), max(x$split)*2))
         for(i in 1:(length(seq_nb_para) - 1) ) { x$split[seq_nb_para[i] <= x$split & x$split < seq_nb_para[i+1]] = i }
         x_split = plyr:::splitter_d(x, .(split))
         return(x_split)
       } )
     } else { d_loc_b = NULL }
-    
+
     return(d_loc_b)
   }
-  
-  
-  
+
+
+
   # 3.2. run function for barplot ----------
-  
+
   if( plot_type == "barplot") {
     if(round(nb_parameters_per_plot/2) != nb_parameters_per_plot/2){nb_parameters_per_plot = nb_parameters_per_plot-1}
-    
+
     fun_barplot = function(data, data_version, nb_parameters_per_plot){
       parameter = group = parameter = NULL # to avoid no visible binding for global variable
-      
+
       if(!is.null(data_version)) {
         data_version$environment = paste(data_version$location, ":", data_version$year, sep = "")
         data_version$parameter = paste("mu[", data_version$germplasm, ",", data_version$environment, "]", sep = "")
-        
+
         # check for env
         vec_env = unique(data_version$environment)
         vec_env_to_get = vec_env[is.element(vec_env, names(data))]
         vec_env_not_to_get = vec_env[!is.element(vec_env, names(data))]
-        if( length(vec_env_not_to_get) > 0 ){ 
-          warning(attributes(data)$PPBstats.object, ": the following environments in data_version are not taken: ", paste(vec_env_not_to_get, collapse = ", "),".") 
+        if( length(vec_env_not_to_get) > 0 ){
+          warning(attributes(data)$PPBstats.object, ": the following environments in data_version are not taken: ", paste(vec_env_not_to_get, collapse = ", "),".")
         }
-        
+
         # check for entry in each element of data (i.e. in each environment)
         vec_entry = data_version$germplasm
         lapply(data, function(x, vec_entry){
           vec_entry_not_ok = vec_entry[!is.element(vec_entry, x$mean.comparisons$entry)]
-          if( length(vec_entry_not_ok) > 0 ) { 
+          if( length(vec_entry_not_ok) > 0 ) {
             warning("The following entries do not exist in ", x$mean.comparisons$environment[1]," : ", paste(vec_entry_not_ok, collapse = ", "), ". The graph is not done." ) }
           }, vec_entry)
 
         # If tests OK, lets go
-        if( length(vec_env_to_get) == 0 ) { 
+        if( length(vec_env_to_get) == 0 ) {
           OUT = NULL
-          warning(attributes(data)$PPBstats.object, ": there are no environment to display") 
+          warning(attributes(data)$PPBstats.object, ": there are no environment to display")
         } else {
           d_env = data[vec_env_to_get]
-          
+
           fun = function(x, data_version, nb_parameters_per_plot){
             Mpvalue = x$Mpvalue
             x = x$mean.comparisons
             p_to_get = dplyr::filter(data_version, environment == x$environment[1])$parameter
             x = dplyr::filter(x, parameter %in% p_to_get)
-            
+
             x = unique(merge(x,data_version[,c("parameter","group")]))
             x = x[order(x$group),]
-            
+
             # Check if we have all the data or if some is missing
             gp = unique(data_version$group)
             for(g in gp){
@@ -255,10 +256,10 @@ plot.mean_comparisons_model_bh_intra_location <- function(
               vec_version = levels(dtmp$version)
               v1 = unique(as.character(dplyr::filter(dtmp, version == vec_version[1])$parameter))
               v2 = unique(as.character(dplyr::filter(dtmp, version == vec_version[2])$parameter))
-              
-              if( !is.null(Mpvalue) ){ 
-                for (i in 1:ncol(Mpvalue)) { 
-                  if(length(v1)>0){if(colnames(Mpvalue)[i] == v1) {c1 = i}} 
+
+              if( !is.null(Mpvalue) ){
+                for (i in 1:ncol(Mpvalue)) {
+                  if(length(v1)>0){if(colnames(Mpvalue)[i] == v1) {c1 = i}}
                   if(length(v2)>0){if (colnames(Mpvalue)[i] == v2) {c2 = i}}
                 }
               }
@@ -270,37 +271,37 @@ plot.mean_comparisons_model_bh_intra_location <- function(
               x$split = add_split_col(x, nb_parameters_per_plot)
               x_split = plyr:::splitter_d(x, .(split))
             }else{x_split=NULL}
-            
+
             return(x_split)
           }
-          
+
           d_env_b = lapply(d_env, fun, data_version, nb_parameters_per_plot)
       #    d_env_b = d_env_b[[!is.null(d_env_b)]]
-          
+
           fun_barplot_version = function(dx, data, data_version){
-            if(attributes(data)$PPBstats.object == "data_mean_comparisons") { 
+            if(attributes(data)$PPBstats.object == "data_mean_comparisons") {
               p = add_stars_version(dx, data, data_version)
             }
-            
+
             if(attributes(data)$PPBstats.object == "data_env_with_no_controls" |
                attributes(data)$PPBstats.object == "data_env_whose_param_did_not_converge") {
               p = add_stars_version(dx, data = NULL, data_version)
             }
-            
+
             return(p)
           }
-          
+
           fun1 = function(x, data){ lapply(x, fun_barplot_version, data, data_version) }
-          
+
           OUT = lapply(d_env_b, fun1, data)
           names(OUT) = names(d_env_b)
           OUT=lapply(OUT,function(x){if(class(x) == "list"){if(length(x) ==0){x=NULL}else{return(x)}}else{return(x)}})
-          
+
           }
-        
-      
+
+
         } else {
-        
+
         d_env_b = lapply(data, function(x){
           x = x$mean.comparisons
           x = dplyr::arrange(x, median)
@@ -309,22 +310,22 @@ plot.mean_comparisons_model_bh_intra_location <- function(
           x_split = plyr:::splitter_d(x, .(split))
           return(x_split)
         } )
-        
+
         OUT = lapply(d_env_b, function(x){
           out = lapply(x, function(dx){
             p = ggplot(dx, aes(x = reorder(parameter, median), y = median)) + geom_bar(stat = "identity")
-            
-            if(attributes(data)$PPBstats.object == "data_mean_comparisons") { 
+
+            if(attributes(data)$PPBstats.object == "data_mean_comparisons") {
               # Add letters of significant groups
               p = p + geom_text(data = dx, aes(x = reorder(parameter, median), y = median/2, label = groups), angle = 90, color = "white")
               p = p + ggtitle(paste(dx[1, "environment"], "\n alpha = ", dx[1, "alpha"], "; alpha correction :", dx[1, "alpha.correction"])) + ylab("")
             }
-            
+
             if(attributes(data)$PPBstats.object == "data_env_with_no_controls" |
                attributes(data)$PPBstats.object == "data_env_whose_param_did_not_converge") {
               p = p + ggtitle(dx[1, "environment"]) + ylab("")
             }
-            
+
             p = p + xlab("") + theme(axis.text.x = element_text(angle = 90)) + ylim(0, dx[1,"max"])
             return(p)
           })
@@ -335,70 +336,70 @@ plot.mean_comparisons_model_bh_intra_location <- function(
       }
       return(OUT)
     }
-    
+
     out = lapply(all_data, fun_barplot, data_version, nb_parameters_per_plot)
     names(out) = names(all_data)
-    
+
   }
-  
+
   # 3.3. run function for score ----------
-  
-  if(plot_type == "score") {  
-    
+
+  if(plot_type == "score") {
+
     d_loc_out = get.loc.year(all_data$data_mean_comparisons, nb_parameters_per_plot)
-    
+
     if( !is.null(d_loc_out) ) {
-      
+
       out = lapply(d_loc_out, function(x){
-        
+
         # assign a number according to the group
         get_score = function(env){
           vec_letters = sort(
             unique(
               unlist(
-                sapply(as.character(env[,"groups"]), 
+                sapply(as.character(env[,"groups"]),
                        function(x){unlist(strsplit(x, ""))})
               )
             )
           )
-          
+
           SCORE = c(1:length(vec_letters))
           names(SCORE) = vec_letters
-          
+
           GP = as.character(env[,"groups"])
           score = NULL
           for(gp in GP){
             score = c(score, mean(SCORE[unlist(strsplit(gp, ""))], na.rm = TRUE))
           }
-          
+
           return(score)
         }
-        
-        
+
+
         t = NULL
         for(i in 1:length(x)) { t = c(t, x[[i]]$year) }
         all_year = unique(t)
-        
+
         all_x = x[[1]]
         if( length(x) > 1 ){
           for(i in 2:length(x)) { all_x = rbind.data.frame(all_x, x[[i]]) }
         }
         all_score = unique(sort(get_score(all_x)))
-        
+
         lapply(x, function(env, all_year, all_score){
           median_text = group = NULL # to avoid no visible binding for global variable
-          
+
           env = dplyr::arrange(env, -median)
-          
+
           # add missing year in order to have the same x axis in all plots
           t = table(env$entry, env$year)
           entry = rownames(t)
           year = colnames(t)
           year_to_add = all_year[!is.element(all_year, year)]
-          
+
           if( length(year_to_add) > 0 ){
             env = rbind.data.frame(
-              env, 
+              env,
               data.frame(
                 parameter = as.factor(NA),
                 median = as.numeric(NA),
@@ -414,8 +415,8 @@ plot.mean_comparisons_model_bh_intra_location <- function(
               )
             )
           }
-          
-          
+
+
           env$group = get_score(env) # group instead of score for the legend
           env$median_text = as.character(round(env$median, 1))
           env = dplyr::arrange(env,-median)
@@ -424,62 +425,62 @@ plot.mean_comparisons_model_bh_intra_location <- function(
           p = ggplot(env, aes(y = entry, x = year, label = median_text, fill = group))
           p = p +  geom_tile() + geom_text()
           p = p + scale_fill_gradient2(low = "red", mid = "white", high = "blue", midpoint = mean(all_score), na.value = "transparent", limits = range(all_score) )
-          p = p + xlab("") + ylab("") + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
+          p = p + xlab("") + ylab("") + theme(axis.text.x = element_text(angle = 90, hjust = 1))
           p = p + ggtitle(paste(env[1, "location"], "; alpha = ", env[1, "alpha"], "; correction : ", env[1, "alpha.correction"], sep = ""))
           return(p)
         }, all_year, all_score)
       })
       names(out) = names(d_loc_out)
     } else { out = NULL }
-    
+
   }
-  
-  
+
+
   # 3.4. run function for interaction ----------
   if(plot_type == "interaction") {
 
     fun_interaction = function(data, nb_parameters_per_plot){
       alpha.info_year = entry = year = NULL # to avoid no visible binding for global variable
-      
+
       d_loc_out = get.loc.year(data, nb_parameters_per_plot)
-      
+
       if( !is.null(d_loc_out) ) {
         out = lapply(d_loc_out, function(x){
           lapply(x, function(x_loc) {
             # Same scale for all the plots
             ymin = min(x_loc$median, na.rm = TRUE)
-            ymax = max(x_loc$median, na.rm = TRUE)  
-            
+            ymax = max(x_loc$median, na.rm = TRUE)
+
             if( attributes(data)$PPBstats.object == "data_mean_comparisons" ){
               alpha.info = paste(x_loc$alpha, "|", x_loc$alpha.correction)
-              x_loc$alpha.info_year = as.factor(paste(x_loc$year, alpha.info, sep = " - "))      
+              x_loc$alpha.info_year = as.factor(paste(x_loc$year, alpha.info, sep = " - "))
             }
-            
-            if( attributes(data)$PPBstats.object == "data_env_with_no_controls" | 
+
+            if( attributes(data)$PPBstats.object == "data_env_with_no_controls" |
                 attributes(data)$PPBstats.object == "data_env_whose_param_did_not_converge"
             ) {
               x_loc$alpha.info_year = x_loc$year
             }
-            
+
             p = ggplot(x_loc, aes(y = median, x = alpha.info_year, colour = entry, group = entry))
             p = p + stat_summary(fun.y = mean, geom = "point") + stat_summary(fun.y = mean, geom = "line") + ggtitle(x_loc[1, "location"])
             p = p + xlab("") + ylab("") + theme(axis.text.x = element_text(angle = 90, hjust = 1), legend.title = element_blank())
-            
-            x_loc_year = plyr:::splitter_d(x_loc, .(year))    
-            
+
+            x_loc_year = plyr:::splitter_d(x_loc, .(year))
+
             # Put lines for significant groups
             if( attributes(data)$PPBstats.object == "data_mean_comparisons" ){
               SEG = NULL
-              
+
               vec_letters = c(letters, paste(rep(LETTERS, times = 15), rep(c(1:5), each = 15), sep = ""))
               gp_letters = vec_letters[1:max(x_loc$nb_group)]
               xadjust = seq(0.05, 0.9, length = 25) # it is assumed max 25 letters (i.e. groups)
               xadjust = xadjust[c(1:length(gp_letters))]
               names(xadjust) = gp_letters
-              
+
               for(i in 1:length(x_loc_year)) {
                 subx = droplevels(x_loc_year[[i]])
-                
+
                 # get rid of non sens information
                 # This is useful if a germplasm is in group 'a' and 'b' alone.
                 # This is possible because other germplasm in groups 'a' and 'b' are in another year
@@ -537,27 +538,27 @@ plot.mean_comparisons_model_bh_intra_location <- function(
 
                 # Initialize the letters
                 if( nrow(m) > 1) {
-                  for(ii in 1:nrow(m)) { 
+                  for(ii in 1:nrow(m)) {
                     m[ii, which(m[ii,] == 1)] = vec_letters[ii]
                     m[ii, which(m[ii,] == 0)] = ""
                     }
-                } else { 
-                  m[1, which(m[1,] == 1)] = vec_letters[1] 
+                } else {
+                  m[1, which(m[1,] == 1)] = vec_letters[1]
                   }
 
                 groups = apply(m, 2, function(x){paste(x, collapse="")})
-                
+
                 subx$groups = factor(groups)
-                
+
                 for(l in gp_letters) {
                   togrep = grep(l, subx[,"groups"])
-                  
+
                   if(length(togrep) > 0) {
                     # check if it is continuous
                     vec.togrep = NULL
-                    
+
                     a = togrep
-                    if( length(a) > 1 ){ 
+                    if( length(a) > 1 ){
                       test = a[1:(length(a)-1)] + 1 == a[2:length(a)]
                       t = c(FALSE, test)
                       t[which(t)] = 1; t[which(!t)] = 0
@@ -566,9 +567,9 @@ plot.mean_comparisons_model_bh_intra_location <- function(
                       c = c(0, cumsum(sapply(b, function(x){nchar(x)})))
                       for(k in 1:(length(c)-1)) { vec.togrep = c(vec.togrep, (a[(c[k]+1):c[k+1]])) }
                     } else { vec.togrep = c(vec.togrep, togrep) }
-                    
+
                     toto = subx[vec.togrep, "median"]
-                    
+
                     y.seg = range(toto)
                     x.seg = i + xadjust[l]
                     alpha.info = paste(as.character(subx[1, "alpha"]),"|", as.character(subx[1, "alpha.correction"]))
@@ -577,35 +578,31 @@ plot.mean_comparisons_model_bh_intra_location <- function(
                   }
                 }
               }
-              
+
               # For germplasm alone in one group, change ymax in order to see it
               for(i in 1:nrow(SEG)){
                 if( SEG$ymin[i] == SEG$ymax[i] ) { SEG$ymax[i] = SEG$ymax[i] + min(SEG$ymax)/30 }
               }
-              
+
               if(!is.null(SEG)) {
                 p = p + geom_segment(aes(x = x, y = ymin, xend = x, yend = ymax, group = NULL), colour =  as.numeric(as.factor(SEG$groups)), data = SEG)
                 p = p + ylim(ymin - ymin/10, ymax + ymax/10) # To be sure to see the line of the groups
-              }      
+              }
             }
-            
-            return(p)        
+
+            return(p)
           })
         } )
         names(out) = names(d_loc_out)
       } else { out = NULL }
-      
+
       return(out)
     }
-    
+
     out = lapply(all_data, fun_interaction, nb_parameters_per_plot)
-    
+
   }
-  
+
   # return results
   return(out)
 }
-
-
-
-


### PR DESCRIPTION
dplyr::join( ) was sometimes creating duplicated columns.
var <- var[!duplicated(as.list(var))] allows to remove these
duplicated rows. This line was added after every occurence of
dplyr::join( )
Automatic deletion of trailing whitespaces